### PR TITLE
Replace mimo_disconnect icon

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
 
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&icon_names=mimo_disconnect" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&icon_names=desktop_access_disabled" />
 
     <!-- Ana stil dosyası; type="text/css" eklenmiştir -->
     <link rel="stylesheet" href="style.css" type="text/css" />

--- a/public/js/uiEvents.js
+++ b/public/js/uiEvents.js
@@ -186,12 +186,12 @@ export function initUIEvents(socket, attemptLogin, attemptRegister) {
           await ScreenShare.startScreenShare(sendTransport, socket);
           screenShareButton.classList.add('active');
           const smallIcon = screenShareButton.querySelector('.material-icons');
-          if (smallIcon) smallIcon.textContent = 'mimo_disconnect';
+          if (smallIcon) smallIcon.textContent = 'desktop_access_disabled';
           if (screenShareLargeButton) screenShareLargeButton.classList.add('active');
           if (screenShareLargeButton) {
             const largeIcon = screenShareLargeButton.querySelector('.material-icons');
           if (largeIcon) {
-            largeIcon.textContent = 'mimo_disconnect';
+            largeIcon.textContent = 'desktop_access_disabled';
             largeIcon.classList.remove('material-icons');
             largeIcon.classList.add('material-icons-outlined');
           }
@@ -229,14 +229,14 @@ export function initUIEvents(socket, attemptLogin, attemptRegister) {
           screenShareLargeButton.classList.add('active');
         const largeIcon = screenShareLargeButton.querySelector('.material-icons');
         if (largeIcon) {
-          largeIcon.textContent = 'mimo_disconnect';
+          largeIcon.textContent = 'desktop_access_disabled';
           largeIcon.classList.remove('material-icons');
           largeIcon.classList.add('material-icons-outlined');
         }
           if (screenShareButton) screenShareButton.classList.add('active');
           if (screenShareButton) {
             const smallIcon = screenShareButton.querySelector('.material-icons');
-            if (smallIcon) smallIcon.textContent = 'mimo_disconnect';
+            if (smallIcon) smallIcon.textContent = 'desktop_access_disabled';
           }
         } catch (error) {
           console.error('Ekran paylaşımı başlatılırken hata:', error);


### PR DESCRIPTION
## Summary
- update Material Symbols link to use `desktop_access_disabled`
- change screen share icon toggle to use the new icon

## Testing
- `npm test` *(fails: cannot find module 'winston', 'dompurify', 'mongoose')*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843516e8e5c8326880c24d4f8f3ae64