### PR TITLE
Add avatars to group user broadcast and mention dropdown

### DIFF
--- a/controllers/groupController.js
+++ b/controllers/groupController.js
@@ -250,8 +250,9 @@ async function broadcastGroupUsers(io, groups, onlineUsernames, Group, groupId) 
     const online = [];
     const offline = [];
     groupDoc.users.forEach(u => {
-      if (onlineUsernames.has(u.username)) online.push({ username: u.username });
-      else offline.push({ username: u.username });
+      const info = { username: u.username, avatar: u.avatar };
+      if (onlineUsernames.has(u.username)) online.push(info);
+      else offline.push(info);
     });
     io.to(groupId).emit('groupUsers', { online, offline });
   } catch (err) {

--- a/public/js/mentions.js
+++ b/public/js/mentions.js
@@ -7,8 +7,8 @@ let activeInput = null;
 export function initMentions(socket) {
   socket.on('groupUsers', (data) => {
     const list = [];
-    if (data && data.online) list.push(...data.online.map(u => u.username));
-    if (data && data.offline) list.push(...data.offline.map(u => u.username));
+    if (data && data.online) list.push(...data.online.map(u => ({ username: u.username, avatar: u.avatar })));
+    if (data && data.offline) list.push(...data.offline.map(u => ({ username: u.username, avatar: u.avatar })));
     groupUsers = list;
   });
 }
@@ -60,17 +60,26 @@ export function handleInput(input) {
   if (at === -1) { hideDropdown(); return; }
   const query = val.slice(at + 1, pos);
   if (/\s/.test(query)) { hideDropdown(); return; }
-  const list = groupUsers.filter(u => u.toLowerCase().startsWith(query.toLowerCase()));
+  const list = groupUsers.filter(u => u.username.toLowerCase().startsWith(query.toLowerCase()));
   if (!list.length) { hideDropdown(); return; }
   const dd = getDropdown();
   dd.innerHTML = '';
   list.forEach((u, i) => {
     const item = document.createElement('div');
     item.className = 'mention-dropdown-item';
-    item.textContent = u;
+    item.dataset.username = u.username;
+    const img = document.createElement('img');
+    img.src = u.avatar || '/images/default-avatar.png';
+    img.width = 24;
+    img.height = 24;
+    img.style.borderRadius = '45%';
+    const nameSpan = document.createElement('span');
+    nameSpan.textContent = u.username;
+    item.appendChild(img);
+    item.appendChild(nameSpan);
     item.addEventListener('mousedown', (e) => {
       e.preventDefault();
-      insertMention(u);
+      insertMention(u.username);
     });
     dd.appendChild(item);
   });
@@ -107,7 +116,7 @@ export function handleKeydown(e) {
   if (e.key === 'Enter') {
     e.preventDefault();
     const item = dropdown.children[selectedIndex];
-    if (item) insertMention(item.textContent);
+    if (item) insertMention(item.dataset.username);
     return true;
   }
   if (e.key === 'Escape') {

--- a/public/style/components/chat.css
+++ b/public/style/components/chat.css
@@ -554,6 +554,9 @@
 }
 
 .mention-dropdown-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   padding: 4px 8px;
   cursor: pointer;
   color: #fff;


### PR DESCRIPTION
## Summary
- broadcast avatar URLs with usernames when sending group users
- show avatar thumbnails in mention dropdown
- style mention dropdown items using flex gap

## Testing
- `npm test` *(fails: Error: Cannot find module 'uuid')*

------
https://chatgpt.com/codex/tasks/task_e_685809309a6c83268ec327f07da79559