### PR TITLE
Fix mention dropdown closing on blur

### DIFF
--- a/public/js/uiEvents.js
+++ b/public/js/uiEvents.js
@@ -485,7 +485,10 @@ export function initUIEvents(socket, attemptLogin, attemptRegister) {
       sendTextMessage();
     }
   });
-  textChannelMessageInput.addEventListener('blur', () => Mentions.hideDropdown());
+  // The mentions dropdown should remain visible on blur so users can
+  // click items without it disappearing. It will be hidden by Mentions
+  // when the @ trigger is removed or becomes invalid.
+  // textChannelMessageInput.addEventListener('blur', () => Mentions.hideDropdown());
 
   const captionInput = document.querySelector('#previewWrapper .caption-input');
   if (captionInput) {


### PR DESCRIPTION
## Summary
- comment out dropdown hide on text input blur

## Testing
- `npm test` *(fails: Cannot find module 'uuid')*
- `bash setup.sh` *(fails: npm install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68580a48b2b883268a5e212b8a39633d