### PR TITLE
Fix dropdown height calculation when mentions list opens

### DIFF
--- a/public/js/mentions.js
+++ b/public/js/mentions.js
@@ -107,9 +107,9 @@ export function handleInput(input) {
   const maxHeight = rect.top - barBottom - gap;
   dd.style.maxHeight = maxHeight + 'px';
   dd.style.left = rect.left + 'px';
+  dd.style.display = 'block';
   const height = Math.min(dd.scrollHeight, maxHeight);
   dd.style.top = (rect.top - height - gap) + 'px';
-  dd.style.display = 'block';
 }
 
 export function handleKeydown(e) {


### PR DESCRIPTION
## Summary
- ensure dropdown is visible before computing its height

## Testing
- `npm test` *(fails: Cannot find module 'uuid')*

------
https://chatgpt.com/codex/tasks/task_e_68581f1e9e908326b07673e64ccf8001