### PR TITLE
Add mute fields to GroupMember model

### DIFF
--- a/models/GroupMember.js
+++ b/models/GroupMember.js
@@ -4,9 +4,15 @@ const GroupMemberSchema = new mongoose.Schema({
   user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
   group: { type: mongoose.Schema.Types.ObjectId, ref: 'Group', required: true },
   unread: { type: Number, default: 0 },
+  muteUntil: { type: Date },
   channelUnreads: {
     type: Map,
     of: Number,
+    default: {}
+  },
+  channelMuteUntil: {
+    type: Map,
+    of: Date,
     default: {}
   }
 });

--- a/test/groupMemberModel.test.js
+++ b/test/groupMemberModel.test.js
@@ -1,0 +1,14 @@
+const test = require('node:test');
+const assert = require('assert');
+const mongoose = require('mongoose');
+const GroupMember = require('../models/GroupMember');
+
+test('default mute fields', () => {
+  const gm = new GroupMember({
+    user: new mongoose.Types.ObjectId(),
+    group: new mongoose.Types.ObjectId()
+  });
+  assert.strictEqual(gm.muteUntil, undefined);
+  assert.ok(gm.channelMuteUntil instanceof Map);
+  assert.strictEqual(gm.channelMuteUntil.size, 0);
+});


### PR DESCRIPTION
## Summary
- track mute timeouts in the group member model
- test new model defaults

## Testing
- `npm test` *(fails: Cannot find module 'uuid')*

------
https://chatgpt.com/codex/tasks/task_e_6858419134288326a7d7d208ab3e08d3