### PR TITLE
Handle muted channels when emitting unread counts

### DIFF
--- a/utils/emitChannelUnread.js
+++ b/utils/emitChannelUnread.js
@@ -3,10 +3,27 @@ async function emitChannelUnread(io, groupId, channelId, Group, userSessions, Gr
     const groupDoc = await Group.findOne({ groupId }).populate('users', 'username');
     if (!groupDoc) return;
     const updates = [];
-    groupDoc.users.forEach(u => {
+    for (const u of groupDoc.users) {
       const sid = userSessions[u.username];
       const inGroup = sid && users[sid]?.currentGroup === groupId;
       const inChannel = sid && users[sid]?.currentTextChannel === channelId;
+
+      const gm = await GroupMember.findOne({ user: u._id, group: groupDoc._id })
+        .select('muteUntil channelMuteUntil');
+      const now = Date.now();
+      const groupMuteUntil = gm?.muteUntil instanceof Date ? gm.muteUntil.getTime() : 0;
+      let channelMuteUntil;
+      if (gm?.channelMuteUntil) {
+        if (typeof gm.channelMuteUntil.get === 'function') {
+          channelMuteUntil = gm.channelMuteUntil.get(channelId);
+        } else {
+          channelMuteUntil = gm.channelMuteUntil[channelId];
+        }
+      }
+      const channelMuteTs = channelMuteUntil instanceof Date ? channelMuteUntil.getTime() : 0;
+      const muteActive = groupMuteUntil > now || channelMuteTs > now;
+      if (muteActive) continue;
+
       const inc = {};
       if (!inGroup) inc.unread = 1;
       if (!inChannel) inc[`channelUnreads.${channelId}`] = 1;
@@ -22,7 +39,7 @@ async function emitChannelUnread(io, groupId, channelId, Group, userSessions, Gr
       if (sid) {
         io.to(sid).emit('channelUnread', { groupId, channelId });
       }
-    });
+    }
     if (updates.length) await Promise.all(updates);
   } catch (err) {
     console.error('emitChannelUnread error:', err);


### PR DESCRIPTION
## Summary
- ensure `emitChannelUnread` checks each member's mute settings
- add tests for channel and group mute behaviour

## Testing
- `npm test` *(fails: Cannot find module 'uuid' et al.)*

------
https://chatgpt.com/codex/tasks/task_e_685843c8c8e08326b032a1710d73134c