### PR TITLE
Add mute submenu and group context menu

### DIFF
--- a/public/js/socketEvents.js
+++ b/public/js/socketEvents.js
@@ -560,6 +560,10 @@ export function initSocketEvents(socket) {
       if (groupObj.id === window.selectedGroup) {
         grpItem.classList.add('selected');
       }
+      grpItem.addEventListener('contextmenu', (e) => {
+        e.preventDefault();
+        window.showGroupContextMenu(e, groupObj);
+      });
       grpItem.addEventListener('click', () => {
         document.querySelectorAll('.grp-item').forEach((el) => el.classList.remove('selected'));
         grpItem.classList.add('selected');


### PR DESCRIPTION
## Summary
- implement `showMuteSubMenu` building duration options
- enhance channel context menu with mute option
- add new `showGroupContextMenu` for groups
- allow right-click on group items to open context menu

## Testing
- `npm test` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_685844fc78a083268a63625ae333034b