### PR TITLE
Fix submenu hide on mouse leave

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -553,6 +553,18 @@ function showMuteSubMenu(target, type) {
   });
 
   document.body.appendChild(subMenu);
+  const removeIfOutside = e => {
+    const to = e.relatedTarget;
+    if (!target.contains(to) && !subMenu.contains(to)) {
+      subMenu.remove();
+      target.removeEventListener('mouseleave', removeIfOutside);
+      subMenu.removeEventListener('mouseleave', removeIfOutside);
+    }
+  };
+
+  target.addEventListener('mouseleave', removeIfOutside);
+  subMenu.addEventListener('mouseleave', removeIfOutside);
+
   document.addEventListener('click', function handler() {
     const m = document.getElementById('muteSubMenu');
     if (m) m.remove();


### PR DESCRIPTION
## Summary
- hide mute submenu when cursor leaves both the menu item and submenu

## Testing
- `npm test` *(fails: Cannot find module 'uuid')*

------
https://chatgpt.com/codex/tasks/task_e_68585cfef70c8326ad18c10cd7b3e7f7