### PR TITLE
Handle mute class on UI

### DIFF
--- a/public/js/socketEvents.js
+++ b/public/js/socketEvents.js
@@ -774,6 +774,7 @@ export function initSocketEvents(socket) {
       if (item) {
         const dot = item.querySelector('.unread-dot');
         if (dot) dot.remove();
+        item.classList.add('muted');
       }
       const total = Object.values(window.channelUnreadCounts[groupId] || {}).reduce((a,b)=>a+(Number(b)||0),0);
       if (total === 0) {
@@ -781,6 +782,7 @@ export function initSocketEvents(socket) {
         if (el) {
           const dot = el.querySelector('.unread-dot');
           if (dot) dot.remove();
+          el.classList.add('muted');
         }
         window.unreadCounter[groupId] = 0;
       }
@@ -790,8 +792,15 @@ export function initSocketEvents(socket) {
   socket.on('muteCleared', ({ groupId, channelId }) => {
     if (channelId) {
       if (window.channelMuteUntil[groupId]) delete window.channelMuteUntil[groupId][channelId];
+      const item = roomListDiv.querySelector(`.channel-item[data-room-id="${channelId}"]`);
+      if (item) item.classList.remove('muted');
     } else if (groupId) {
       delete window.groupMuteUntil[groupId];
+      const el = groupListDiv.querySelector(`.grp-item[data-group-id="${groupId}"]`);
+      if (el) el.classList.remove('muted');
+      if (groupId === window.selectedGroup) {
+        roomListDiv.querySelectorAll('.channel-item').forEach(ci => ci.classList.remove('muted'));
+      }
     }
   });
 
@@ -806,7 +815,10 @@ export function initSocketEvents(socket) {
       window.channelMuteUntil[window.selectedGroup] &&
       window.channelMuteUntil[window.selectedGroup][roomObj.id];
     const cMuted = cMuteTs && Date.now() < cMuteTs;
-    if (gMuted || cMuted) unreadCount = 0;
+    if (gMuted || cMuted) {
+      unreadCount = 0;
+      roomItem.classList.add('muted');
+    }
     if (roomObj.type === 'text' && unreadCount > 0) {
       const dot = document.createElement('span');
       dot.className = 'unread-dot';

--- a/public/style/components/channel.css
+++ b/public/style/components/channel.css
@@ -305,6 +305,10 @@
   color: #ccc;
   font-size: 0.9rem;
 }
+.channel-item.muted .channel-icon,
+.channel-item.muted .channel-name {
+  color: #888;
+}
 .group-name {
   color: #ddd;
   font-weight: 600;

--- a/public/style/layout.css
+++ b/public/style/layout.css
@@ -68,6 +68,9 @@
   border: 2px solid #c61884;
   border-radius: 15px;
 }
+.grp-item.muted {
+  color: #888;
+}
 
 .grp-item .unread-dot {
   position: absolute;


### PR DESCRIPTION
## Summary
- show muted state for group and channel list items
- toggle class on mute events

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_e_68594b0c48a4832695a2d827b539057d