### PR TITLE
Add immediate channel mute styling

### DIFF
--- a/public/js/socketEvents.js
+++ b/public/js/socketEvents.js
@@ -203,11 +203,11 @@ export function initSocketEvents(socket) {
         delete window.groupMuteUntil[gid];
         socket.emit('muteGroup', { groupId: gid, duration: 0 });
         const el = groupListDiv.querySelector(`.grp-item[data-group-id="${gid}"]`);
-        if (el) el.classList.remove('muted');
+        if (el) el.classList.remove('muted', 'channel-muted');
         if (gid === window.selectedGroup) {
           roomListDiv
             .querySelectorAll('.channel-item')
-            .forEach((ci) => ci.classList.remove('muted'));
+            .forEach((ci) => ci.classList.remove('muted', 'channel-muted'));
         }
       }
     });
@@ -227,7 +227,7 @@ export function initSocketEvents(socket) {
             const item = roomListDiv.querySelector(
               `.channel-item[data-room-id="${cid}"]`
             );
-            if (item) item.classList.remove('muted');
+            if (item) item.classList.remove('muted', 'channel-muted');
           }
         }
       });
@@ -813,7 +813,7 @@ export function initSocketEvents(socket) {
       if (item) {
         const dot = item.querySelector('.unread-dot');
         if (dot) dot.remove();
-        item.classList.add('muted');
+        item.classList.add('muted', 'channel-muted');
       }
       const total = Object.values(window.channelUnreadCounts[groupId] || {}).reduce((a,b)=>a+(Number(b)||0),0);
       if (total === 0) {
@@ -832,13 +832,13 @@ export function initSocketEvents(socket) {
     if (channelId) {
       if (window.channelMuteUntil[groupId]) delete window.channelMuteUntil[groupId][channelId];
       const item = roomListDiv.querySelector(`.channel-item[data-room-id="${channelId}"]`);
-      if (item) item.classList.remove('muted');
+      if (item) item.classList.remove('muted', 'channel-muted');
     } else if (groupId) {
       delete window.groupMuteUntil[groupId];
       const el = groupListDiv.querySelector(`.grp-item[data-group-id="${groupId}"]`);
       if (el) el.classList.remove('muted');
       if (groupId === window.selectedGroup) {
-        roomListDiv.querySelectorAll('.channel-item').forEach(ci => ci.classList.remove('muted'));
+        roomListDiv.querySelectorAll('.channel-item').forEach(ci => ci.classList.remove('muted', 'channel-muted'));
       }
     }
   });
@@ -856,7 +856,7 @@ export function initSocketEvents(socket) {
     const cMuted = cMuteTs && Date.now() < cMuteTs;
     if (gMuted || cMuted) {
       unreadCount = 0;
-      roomItem.classList.add('muted');
+      roomItem.classList.add('muted', 'channel-muted');
     }
     if (roomObj.type === 'text' && unreadCount > 0) {
       const dot = document.createElement('span');

--- a/public/script.js
+++ b/public/script.js
@@ -550,8 +550,8 @@ function showMuteSubMenu(target, type) {
         if (gid === window.selectedGroup) {
           const el = document.querySelector(`.channel-item[data-room-id="${cid}"]`);
           if (el) {
-            if (d.ms > 0) el.classList.add('muted');
-            else el.classList.remove('muted');
+            if (d.ms > 0) el.classList.add('muted', 'channel-muted');
+            else el.classList.remove('muted', 'channel-muted');
           }
         }
       } else if (type === 'group') {

--- a/public/style/components/channel.css
+++ b/public/style/components/channel.css
@@ -306,7 +306,9 @@
   font-size: 0.9rem;
 }
 .channel-item.muted .channel-icon,
-.channel-item.muted .channel-name {
+.channel-item.muted .channel-name,
+.channel-item.channel-muted .channel-icon,
+.channel-item.channel-muted .channel-name {
   color: #888;
 }
 .group-name {


### PR DESCRIPTION
## Summary
- add `.channel-muted` CSS rule to update icon/name colors
- toggle `.channel-muted` class when muting or unmuting channels
- reflect class in socket event handlers

## Testing
- `npm test` *(fails: Cannot find module 'uuid')*


------
https://chatgpt.com/codex/tasks/task_e_6859578d31ec8326829fdc4baa5f09bf