### PR TITLE
Style unread highlights

### DIFF
--- a/public/js/socketEvents.js
+++ b/public/js/socketEvents.js
@@ -600,6 +600,7 @@ export function initSocketEvents(socket) {
         const dot = document.createElement('span');
         dot.className = 'unread-dot';
         grpItem.appendChild(dot);
+        grpItem.classList.add('unread');
       }
       if (groupObj.id === window.selectedGroup) {
         grpItem.classList.add('selected');
@@ -689,6 +690,7 @@ export function initSocketEvents(socket) {
     if (el) {
       const dot = el.querySelector('.unread-dot');
       if (dot) dot.remove();
+      el.classList.remove('unread');
     }
     if (window.unreadCounter[groupId]) {
       window.unreadCounter[groupId] = 0;
@@ -715,6 +717,7 @@ export function initSocketEvents(socket) {
         dot.className = 'unread-dot';
         el.appendChild(dot);
       }
+      if (el) el.classList.add('unread');
       if (groupId === window.selectedGroup) {
         const item = roomListDiv.querySelector(
           `.channel-item[data-room-id="${channelId}"]`
@@ -724,6 +727,7 @@ export function initSocketEvents(socket) {
           dot.className = 'unread-dot';
           item.appendChild(dot);
         }
+        if (item) item.classList.add('unread');
       }
     }
   });
@@ -734,6 +738,7 @@ export function initSocketEvents(socket) {
       if (el && window.unreadCounter[groupId] === 0) {
         const dot = el.querySelector('.unread-dot');
         if (dot) dot.remove();
+        el.classList.remove('unread');
       }
     }
     if (window.channelUnreadCounts[groupId]) {
@@ -744,6 +749,7 @@ export function initSocketEvents(socket) {
       if (item) {
         const dot = item.querySelector('.unread-dot');
         if (dot) dot.remove();
+        item.classList.remove('unread');
       }
     }
   });
@@ -754,13 +760,20 @@ export function initSocketEvents(socket) {
       const total = Object.values(channels).reduce((a, b) => a + (Number(b) || 0), 0);
       const gMuteTs = window.groupMuteUntil[gid];
       const gMuted = gMuteTs && Date.now() < gMuteTs;
+      const el = groupListDiv.querySelector(`.grp-item[data-group-id="${gid}"]`);
       if (total > 0 && !gMuted) {
         window.unreadCounter[gid] = total;
-        const el = groupListDiv.querySelector(`.grp-item[data-group-id="${gid}"]`);
         if (el && !el.querySelector('.unread-dot')) {
           const dot = document.createElement('span');
           dot.className = 'unread-dot';
           el.appendChild(dot);
+        }
+        if (el) el.classList.add('unread');
+      } else {
+        if (el) {
+          const dot = el.querySelector('.unread-dot');
+          if (dot) dot.remove();
+          el.classList.remove('unread');
         }
       }
       if (gid === window.selectedGroup) {
@@ -776,6 +789,11 @@ export function initSocketEvents(socket) {
             item.appendChild(dot);
           } else if ((count === 0 || muted) && dot) {
             dot.remove();
+          }
+          if (count > 0 && !muted) {
+            item.classList.add('unread');
+          } else {
+            item.classList.remove('unread');
           }
         });
       }
@@ -796,10 +814,16 @@ export function initSocketEvents(socket) {
     if (el) {
       const dot = el.querySelector('.unread-dot');
       if (dot) dot.remove();
+      el.classList.remove('unread');
+      el.classList.add('muted');
     }
     window.unreadCounter[groupId] = 0;
     if (groupId === window.selectedGroup) {
-      roomListDiv.querySelectorAll('.channel-item .unread-dot').forEach(d => d.remove());
+      roomListDiv.querySelectorAll('.channel-item').forEach(ci => {
+        const d = ci.querySelector('.unread-dot');
+        if (d) d.remove();
+        ci.classList.remove('unread');
+      });
       if (window.channelUnreadCounts[groupId]) {
         Object.keys(window.channelUnreadCounts[groupId]).forEach(cid => {
           window.channelUnreadCounts[groupId][cid] = 0;
@@ -825,6 +849,7 @@ export function initSocketEvents(socket) {
       if (item) {
         const dot = item.querySelector('.unread-dot');
         if (dot) dot.remove();
+        item.classList.remove('unread');
         item.classList.add('muted', 'channel-muted');
       }
       const total = Object.values(window.channelUnreadCounts[groupId] || {}).reduce((a,b)=>a+(Number(b)||0),0);
@@ -833,6 +858,7 @@ export function initSocketEvents(socket) {
         if (el) {
           const dot = el.querySelector('.unread-dot');
           if (dot) dot.remove();
+          el.classList.remove('unread');
           el.classList.add('muted');
         }
         window.unreadCounter[groupId] = 0;
@@ -874,6 +900,7 @@ export function initSocketEvents(socket) {
       const dot = document.createElement('span');
       dot.className = 'unread-dot';
       roomItem.appendChild(dot);
+      roomItem.classList.add('unread');
     }
     if (!window.channelUnreadCounts[window.selectedGroup]) {
       window.channelUnreadCounts[window.selectedGroup] = {};

--- a/public/style/components/channel.css
+++ b/public/style/components/channel.css
@@ -302,14 +302,19 @@
 }
 .channel-name {
   font-weight: 400;
-  color: #ccc;
+  color: #aaa;
   font-size: 0.9rem;
+}
+
+.channel-item.unread:not(.muted) .channel-icon,
+.channel-item.unread:not(.muted) .channel-name {
+  color: #eee;
 }
 .channel-item.muted .channel-icon,
 .channel-item.muted .channel-name,
 .channel-item.channel-muted .channel-icon,
 .channel-item.channel-muted .channel-name {
-  color: #888;
+  color: #575757;
 }
 .group-name {
   color: #ddd;

--- a/public/style/layout.css
+++ b/public/style/layout.css
@@ -51,7 +51,7 @@
   width: 43px;
   height: 43px;
   background: #444;
-  color: #fff;
+  color: #aaa;
   border-radius: 45%;
   display: flex;
   justify-content: center;
@@ -69,7 +69,7 @@
   border-radius: 15px;
 }
 .grp-item.muted {
-  color: #888;
+  color: #575757;
 }
 
 .grp-item .unread-dot {
@@ -79,7 +79,7 @@
   transform: translateY(-50%);
   width: 10px;
   height: 10px;
-  background: #ffffff;
+  background: #eee;
   border-radius: 50%;
   pointer-events: none;
 }

--- a/test/unreadClass.test.js
+++ b/test/unreadClass.test.js
@@ -1,0 +1,50 @@
+const test = require('node:test');
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const { JSDOM } = require('jsdom');
+
+async function setup() {
+  const dom = new JSDOM('<!doctype html><div id="groupList"></div><div id="roomList"></div><div id="groupTitle"></div><div id="selectedChannelTitle"></div>');
+  global.window = dom.window;
+  global.document = dom.window.document;
+  window.groupListDiv = document.getElementById('groupList');
+  window.roomListDiv = document.getElementById('roomList');
+  window.groupTitle = document.getElementById('groupTitle');
+  window.selectedChannelTitle = document.getElementById('selectedChannelTitle');
+  window.textChannelContainer = document.createElement('div');
+  window.hideVoiceSections = () => {};
+  window.loadAvatar = async () => '/a.png';
+  window.showGroupContextMenu = () => {};
+  window.showChannelContextMenu = () => {};
+  window.updateVoiceChannelUI = () => {};
+  window.joinRoom = () => {};
+  window.clearScreenShareUI = () => {};
+  window.applyAudioStates = () => {};
+  window.showChannelStatusPanel = () => {};
+  window.textMessages = document.createElement('div');
+  const mod = await import('../public/js/socketEvents.js');
+  const socket = new EventEmitter();
+  mod.initSocketEvents(socket);
+  return { socket };
+}
+
+test('unread class toggles and mute clears it', async () => {
+  const { socket } = await setup();
+  window.selectedGroup = 'g1';
+  socket.emit('groupsList', [{ id: 'g1', name: 'G1', owner: 'u1' }]);
+  socket.emit('roomsList', [{ id: 'c1', name: 'C1', type: 'text', unreadCount: 0 }]);
+  const groupItem = window.groupListDiv.querySelector('.grp-item');
+  const channelItem = window.roomListDiv.querySelector('.channel-item');
+  window.currentTextChannel = null;
+  socket.emit('channelUnread', { groupId: 'g1', channelId: 'c1' });
+  assert.ok(groupItem.classList.contains('unread'));
+  assert.ok(channelItem.classList.contains('unread'));
+  socket.emit('channelRead', { groupId: 'g1', channelId: 'c1' });
+  assert.ok(!groupItem.classList.contains('unread'));
+  assert.ok(!channelItem.classList.contains('unread'));
+  socket.emit('channelUnread', { groupId: 'g1', channelId: 'c1' });
+  socket.emit('channelMuted', { groupId: 'g1', channelId: 'c1', muteUntil: Date.now() + 1000 });
+  assert.ok(channelItem.classList.contains('muted'));
+  assert.ok(!channelItem.classList.contains('unread'));
+  assert.ok(!groupItem.classList.contains('unread'));
+});


### PR DESCRIPTION
## Summary
- tweak channel and group colors
- flag unread items with a class in socket events
- test DOM class handling

## Testing
- `npm test` *(fails: Cannot find module 'uuid', 'bcryptjs', 'mongoose', 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_6859619fcee48326b8b4b413c4486e60