### PR TITLE
Add mute info emission on login

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -2,6 +2,7 @@
 const bcrypt = require('bcryptjs');
 
 const collectUnreadCounts = require('../utils/collectUnreadCounts');
+const collectMuteInfo = require('../utils/collectMuteInfo');
 
 function registerAuthHandlers(io, socket, context) {
   const { User, Group, GroupMember, users, onlineUsernames, groupController } = context;
@@ -104,6 +105,8 @@ function registerAuthHandlers(io, socket, context) {
       if (Group && GroupMember) {
         const unread = await collectUnreadCounts(trimmedName, { User, Group, GroupMember });
         socket.emit('unreadCounts', unread);
+        const mutes = await collectMuteInfo(trimmedName, { User, Group, GroupMember });
+        socket.emit('activeMutes', mutes);
       }
     }
   });

--- a/test/activeMutesEmit.test.js
+++ b/test/activeMutesEmit.test.js
@@ -1,0 +1,43 @@
+const test = require('node:test');
+const assert = require('assert');
+const { EventEmitter } = require('events');
+
+const registerAuthHandlers = require('../controllers/authController');
+
+function query(doc) {
+  return { populate: async () => doc };
+}
+
+function createContext() {
+  const io = { to(){ return { emit: () => {} }; }, sockets:{ sockets: new Map() } };
+  const socket = new EventEmitter();
+  socket.id = 's1';
+  io.sockets.sockets.set('s1', socket);
+
+  const future = new Date(Date.now() + 1000);
+  const userDoc = { _id: 'u1id', groups: [{ _id: 'g1id', groupId: 'g1' }] };
+  const User = { findOne: async q => q.username === 'u1' ? query(userDoc) : query(null) };
+  const Group = {};
+  const GroupMember = { findOne: async () => ({ muteUntil: future, channelMuteUntil: new Map() }) };
+  const ctx = {
+    User,
+    Group,
+    GroupMember,
+    users: { s1: {} },
+    onlineUsernames: new Set(),
+    groupController: { async sendGroupsListToUser() {} },
+    store: null,
+    userSessions: {}
+  };
+  return { io, socket, ctx, future };
+}
+
+test('set-username emits activeMutes info', async () => {
+  const { io, socket, ctx, future } = createContext();
+  registerAuthHandlers(io, socket, ctx);
+  let emitted;
+  socket.emit = (ev, data) => { if(ev==='activeMutes') emitted = data; };
+  const handler = socket.listeners('set-username')[0];
+  await handler('u1');
+  assert.deepStrictEqual(emitted, { g1: { muteUntil: future } });
+});

--- a/test/collectMuteInfo.test.js
+++ b/test/collectMuteInfo.test.js
@@ -1,0 +1,19 @@
+const test = require('node:test');
+const assert = require('assert');
+
+const collectMuteInfo = require('../utils/collectMuteInfo');
+
+function query(doc) {
+  return { populate: async () => doc };
+}
+
+test('collectMuteInfo filters out expired entries', async () => {
+  const now = Date.now();
+  const userDoc = { _id: 'u1id', groups: [{ _id: 'g1id', groupId: 'g1' }] };
+  const User = { findOne: async q => q.username === 'u1' ? query(userDoc) : query(null) };
+  const Group = {};
+  const gm = { muteUntil: new Date(now - 1000), channelMuteUntil: new Map([['c1', new Date(now - 1000)]]) };
+  const GroupMember = { findOne: async () => gm };
+  const res = await collectMuteInfo('u1', { User, Group, GroupMember });
+  assert.deepStrictEqual(res, {});
+});

--- a/utils/collectMuteInfo.js
+++ b/utils/collectMuteInfo.js
@@ -1,0 +1,34 @@
+const getEntries = map => {
+  if (!map) return [];
+  if (typeof map.entries === 'function') return Array.from(map.entries());
+  return Object.entries(map);
+};
+
+async function collectMuteInfo(username, { User, Group, GroupMember }) {
+  const result = {};
+  try {
+    const userDoc = await User.findOne({ username }).populate('groups');
+    if (!userDoc) return result;
+    const now = Date.now();
+    await Promise.all(userDoc.groups.map(async g => {
+      const gm = await GroupMember.findOne({ user: userDoc._id, group: g._id })
+        .select('muteUntil channelMuteUntil');
+      if (!gm) return;
+      const groupMuteTs = gm.muteUntil instanceof Date ? gm.muteUntil.getTime() : 0;
+      const channelMuteEntries = getEntries(gm.channelMuteUntil)
+        .filter(([, ts]) => ts instanceof Date && ts.getTime() > now);
+      const activeChan = Object.fromEntries(channelMuteEntries);
+      if (groupMuteTs > now || channelMuteEntries.length > 0) {
+        const entry = {};
+        if (groupMuteTs > now) entry.muteUntil = gm.muteUntil;
+        if (channelMuteEntries.length > 0) entry.channelMuteUntil = activeChan;
+        result[g.groupId] = entry;
+      }
+    }));
+  } catch (err) {
+    console.error('collectMuteInfo error:', err);
+  }
+  return result;
+}
+
+module.exports = collectMuteInfo;


### PR DESCRIPTION
## Summary
- gather active mute info with new helper `collectMuteInfo`
- emit `activeMutes` from the `set-username` handler
- cover mute collection and emission with tests

## Testing
- `npm test` *(fails: Cannot find module 'bcryptjs', 'uuid', 'mongoose', 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_68598aa1e96483269b5ab3ef9a0ff381