### PR TITLE
Fix individual channel mutes surviving group unmute

### DIFF
--- a/public/js/socketEvents.js
+++ b/public/js/socketEvents.js
@@ -207,7 +207,15 @@ export function initSocketEvents(socket) {
         if (gid === window.selectedGroup) {
           roomListDiv
             .querySelectorAll('.channel-item')
-            .forEach((ci) => ci.classList.remove('muted', 'channel-muted'));
+            .forEach((ci) => {
+              ci.classList.remove('muted', 'channel-muted');
+              const cid = ci.dataset.roomId;
+              const ts =
+                window.channelMuteUntil[gid] && window.channelMuteUntil[gid][cid];
+              if (ts && Date.now() < ts) {
+                ci.classList.add('muted', 'channel-muted');
+              }
+            });
         }
       }
     });
@@ -905,7 +913,15 @@ export function initSocketEvents(socket) {
       const el = groupListDiv.querySelector(`.grp-item[data-group-id="${groupId}"]`);
       if (el) el.classList.remove('muted');
       if (groupId === window.selectedGroup) {
-        roomListDiv.querySelectorAll('.channel-item').forEach(ci => ci.classList.remove('muted', 'channel-muted'));
+        roomListDiv.querySelectorAll('.channel-item').forEach(ci => {
+          ci.classList.remove('muted', 'channel-muted');
+          const cid = ci.dataset.roomId;
+          const ts =
+            window.channelMuteUntil[groupId] && window.channelMuteUntil[groupId][cid];
+          if (ts && Date.now() < ts) {
+            ci.classList.add('muted', 'channel-muted');
+          }
+        });
       }
     }
   });

--- a/test/unreadClass.test.js
+++ b/test/unreadClass.test.js
@@ -48,3 +48,22 @@ test('unread class toggles and mute clears it', async () => {
   assert.ok(!channelItem.classList.contains('unread'));
   assert.ok(!groupItem.classList.contains('unread'));
 });
+
+test('group unmute preserves individual channel mute', async () => {
+  const { socket } = await setup();
+  window.selectedGroup = 'g1';
+  socket.emit('groupsList', [{ id: 'g1', name: 'G1', owner: 'u1' }]);
+  socket.emit('roomsList', [
+    { id: 'c1', name: 'C1', type: 'text', unreadCount: 0 },
+    { id: 'c2', name: 'C2', type: 'text', unreadCount: 0 }
+  ]);
+  const ch1 = window.roomListDiv.querySelector('[data-room-id="c1"]');
+  const ch2 = window.roomListDiv.querySelector('[data-room-id="c2"]');
+
+  socket.emit('channelMuted', { groupId: 'g1', channelId: 'c2', muteUntil: Date.now() + 1000 });
+  socket.emit('groupMuted', { groupId: 'g1', muteUntil: Date.now() + 1000 });
+  socket.emit('muteCleared', { groupId: 'g1' });
+
+  assert.ok(!ch1.classList.contains('muted'));
+  assert.ok(ch2.classList.contains('muted'));
+});


### PR DESCRIPTION
## Summary
- keep channel-level mute classes when a group mute is cleared
- adjust periodic mute expiry check to respect per-channel mutes
- test DOM behaviour for preserving channel mute after group unmute

## Testing
- `npm test` *(fails: npm attempted to access the network)*

------
https://chatgpt.com/codex/tasks/task_e_685994294f58832698d7a18dc8a3276e