### PR TITLE
Add mention unread notifications

### DIFF
--- a/public/style/components/channel.css
+++ b/public/style/components/channel.css
@@ -35,6 +35,9 @@
   border-radius: 50%;
   pointer-events: none;
 }
+.channel-item .mention-dot {
+  background: #c61884;
+}
 .channel-header {
   display: flex;
   align-items: center;

--- a/public/style/layout.css
+++ b/public/style/layout.css
@@ -83,6 +83,9 @@
   border-radius: 50%;
   pointer-events: none;
 }
+.grp-item .mention-dot {
+  background: #c61884;
+}
 
 /* Odalar Paneli */
 .rooms-panel {

--- a/test/mentionDotClient.test.js
+++ b/test/mentionDotClient.test.js
@@ -1,0 +1,52 @@
+const test = require('node:test');
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const { JSDOM } = require('jsdom');
+
+async function setup() {
+  const dom = new JSDOM('<!doctype html><div id="groupList"></div><div id="roomList"></div><div id="groupTitle"></div><div id="selectedChannelTitle"></div>');
+  global.window = dom.window;
+  global.document = dom.window.document;
+  window.groupListDiv = document.getElementById('groupList');
+  window.roomListDiv = document.getElementById('roomList');
+  window.groupTitle = document.getElementById('groupTitle');
+  window.selectedChannelTitle = document.getElementById('selectedChannelTitle');
+  window.textChannelContainer = document.createElement('div');
+  window.hideVoiceSections = () => {};
+  window.loadAvatar = async () => '/a.png';
+  window.showGroupContextMenu = () => {};
+  window.showChannelContextMenu = () => {};
+  window.updateVoiceChannelUI = () => {};
+  window.joinRoom = () => {};
+  window.clearScreenShareUI = () => {};
+  window.applyAudioStates = () => {};
+  window.showChannelStatusPanel = () => {};
+  window.textMessages = document.createElement('div');
+  const mod = await import('../public/js/socketEvents.js');
+  const socket = new EventEmitter();
+  mod.initSocketEvents(socket);
+  return { socket };
+}
+
+test('mention dot added and removed correctly', async () => {
+  const { socket } = await setup();
+  window.selectedGroup = 'g1';
+  socket.emit('groupsList', [{ id: 'g1', name: 'G1', owner: 'u1' }]);
+  socket.emit('roomsList', [
+    { id: 'c1', name: 'C1', type: 'text', unreadCount: 0 },
+    { id: 'c2', name: 'C2', type: 'text', unreadCount: 0 }
+  ]);
+  window.currentTextChannel = 'c2';
+  socket.emit('channelUnread', { groupId: 'g1', channelId: 'c2' });
+  socket.emit('channelUnread', { groupId: 'g1', channelId: 'c1' });
+  socket.emit('mentionUnread', { groupId: 'g1', channelId: 'c1' });
+  const groupItem = window.groupListDiv.querySelector('.grp-item');
+  const mentionDot = groupItem.querySelector('.unread-dot');
+  assert.ok(mentionDot.classList.contains('mention-dot'));
+  const ch1 = window.roomListDiv.querySelector('[data-room-id="c1"]');
+  const cDot = ch1.querySelector('.unread-dot');
+  assert.ok(cDot.classList.contains('mention-dot'));
+  socket.emit('channelRead', { groupId: 'g1', channelId: 'c1' });
+  const gDot = groupItem.querySelector('.unread-dot');
+  assert.ok(gDot && !gDot.classList.contains('mention-dot'));
+});

--- a/test/mentionUnread.test.js
+++ b/test/mentionUnread.test.js
@@ -1,0 +1,52 @@
+const test = require('node:test');
+const assert = require('assert');
+const emitMentionUnread = require('../utils/emitMentionUnread');
+
+function createContext(opts = {}) {
+  const groupDoc = {
+    _id: 'gid1',
+    groupId: 'g1',
+    users: [
+      { _id: 'uid1', username: 'u1' },
+      { _id: 'uid2', username: 'u2' }
+    ]
+  };
+  const Group = {
+    findOne: async (q) => (q.groupId === 'g1' ? { populate: async () => groupDoc } : null)
+  };
+  const GroupMember = {
+    async findOne(q) {
+      if (q.user === 'uid2') {
+        return {
+          muteUntil: opts.muteUntil,
+          channelMuteUntil: new Map(Object.entries(opts.channelMuteUntil || {}))
+        };
+      }
+      return null;
+    }
+  };
+  const userSessions = { u2: 's2' };
+  const users = { s2: { currentGroup: opts.currentGroup, currentTextChannel: opts.currentChannel } };
+  const io = { emitted: [], to: () => ({ emit(ev,p){ io.emitted.push({ev,p}); } }) };
+  return { io, Group, GroupMember, userSessions, users };
+}
+
+test('emitMentionUnread sends event for valid mention', async () => {
+  const ctx = createContext({ currentGroup: 'g1', currentChannel: 'other' });
+  await emitMentionUnread(ctx.io, 'g1', 'ch1', 'u2', ctx.Group, ctx.userSessions, ctx.GroupMember, ctx.users);
+  assert.strictEqual(ctx.io.emitted.length, 1);
+  assert.strictEqual(ctx.io.emitted[0].ev, 'mentionUnread');
+});
+
+test('emitMentionUnread ignores when viewing channel', async () => {
+  const ctx = createContext({ currentGroup: 'g1', currentChannel: 'ch1' });
+  await emitMentionUnread(ctx.io, 'g1', 'ch1', 'u2', ctx.Group, ctx.userSessions, ctx.GroupMember, ctx.users);
+  assert.strictEqual(ctx.io.emitted.length, 0);
+});
+
+test('emitMentionUnread ignores when muted', async () => {
+  const muteUntil = new Date(Date.now() + 1000);
+  const ctx = createContext({ currentGroup: 'g1', currentChannel: 'other', muteUntil });
+  await emitMentionUnread(ctx.io, 'g1', 'ch1', 'u2', ctx.Group, ctx.userSessions, ctx.GroupMember, ctx.users);
+  assert.strictEqual(ctx.io.emitted.length, 0);
+});

--- a/utils/emitMentionUnread.js
+++ b/utils/emitMentionUnread.js
@@ -1,0 +1,33 @@
+async function emitMentionUnread(io, groupId, channelId, username, Group, userSessions, GroupMember, users) {
+  try {
+    const groupDoc = await Group.findOne({ groupId }).populate('users', 'username');
+    if (!groupDoc) return;
+    const target = groupDoc.users.find(u => u.username === username);
+    if (!target) return;
+    const sid = userSessions[username];
+    const inGroup = sid && users[sid]?.currentGroup === groupId;
+    const inChannel = sid && users[sid]?.currentTextChannel === channelId;
+    const gm = await GroupMember.findOne({ user: target._id, group: groupDoc._id })
+      .select('muteUntil channelMuteUntil');
+    const now = Date.now();
+    const groupMuteUntil = gm?.muteUntil instanceof Date ? gm.muteUntil.getTime() : 0;
+    let channelMuteUntil;
+    if (gm?.channelMuteUntil) {
+      if (typeof gm.channelMuteUntil.get === 'function') {
+        channelMuteUntil = gm.channelMuteUntil.get(channelId);
+      } else {
+        channelMuteUntil = gm.channelMuteUntil[channelId];
+      }
+    }
+    const channelMuteTs = channelMuteUntil instanceof Date ? channelMuteUntil.getTime() : 0;
+    const muteActive = groupMuteUntil > now || channelMuteTs > now;
+    if (muteActive || inChannel) return;
+    if (sid) {
+      io.to(sid).emit('mentionUnread', { groupId, channelId });
+    }
+  } catch (err) {
+    console.error('emitMentionUnread error:', err);
+  }
+}
+
+module.exports = emitMentionUnread;


### PR DESCRIPTION
## Summary
- support mention-specific unread dots in CSS
- emit mentionUnread events server-side
- parse mentions when sending messages
- display mention unread dots in the client and clear them when read
- test mentionUnread utility and client behavior

## Testing
- `npm test` *(fails: Cannot find module 'bcryptjs')*

------
https://chatgpt.com/codex/tasks/task_e_68599e6321b08326808633bead510096