### PR TITLE
Fix unread dot clearing when channel opened

### DIFF
--- a/public/js/textChannel.js
+++ b/public/js/textChannel.js
@@ -496,6 +496,7 @@ function initTextChannelEvents(socket, container) {
 
   socket.on('textHistory', (messages) => {
     renderTextMessages(messages, container);
+    markReadIfAtBottom();
   });
 
   socket.on('newTextMessage', (data) => {

--- a/test/groupUnreadPersist.test.js
+++ b/test/groupUnreadPersist.test.js
@@ -51,10 +51,9 @@ test('group unread dot persists until channel read', async () => {
 
   window.textMessages.clientHeight = 100;
   window.textMessages.scrollHeight = 100;
-  window.textMessages.scrollTop = 0;
-  window.textMessages.dispatchEvent(new window.Event('scroll', { bubbles: true }));
+  socket.emit('textHistory', []);
 
-  assert.strictEqual(emitted.length, 1, 'markChannelRead emitted after scroll');
+  assert.strictEqual(emitted.length, 1, 'markChannelRead emitted after history');
   socket.emit('channelRead', { groupId: 'g1', channelId: 'c1' });
   const dotAfterRead = groupItem.querySelector('.unread-dot');
   assert.ok(!dotAfterRead, 'dot removed after read');


### PR DESCRIPTION
## Summary
- mark channels read if the last message is visible after text history loads
- adjust unread persistence test to expect markChannelRead on history event

## Testing
- `npm test` *(fails: Cannot find module 'bcryptjs')*


------
https://chatgpt.com/codex/tasks/task_e_685a8659c16c8326ac9406b26f7dbdb1