### PR TITLE
Add notification preference sync

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -4,6 +4,7 @@ const bcrypt = require('bcryptjs');
 const collectUnreadCounts = require('../utils/collectUnreadCounts');
 const collectMentionCounts = require('../utils/collectMentionCounts');
 const collectMuteInfo = require('../utils/collectMuteInfo');
+const collectNotifyInfo = require('../utils/collectNotifyInfo');
 
 function registerAuthHandlers(io, socket, context) {
   const { User, Group, GroupMember, users, onlineUsernames, groupController } = context;
@@ -110,6 +111,8 @@ function registerAuthHandlers(io, socket, context) {
         socket.emit('unreadCounts', unread);
         const mutes = await collectMuteInfo(trimmedName, { User, Group, GroupMember });
         socket.emit('activeMutes', mutes);
+        const notify = await collectNotifyInfo(trimmedName, { User, Group, GroupMember });
+        socket.emit('activeNotifyTypes', notify);
       }
     }
   });

--- a/public/js/socketEvents.js
+++ b/public/js/socketEvents.js
@@ -930,6 +930,19 @@ export function initSocketEvents(socket) {
     });
   });
 
+  socket.on('activeNotifyTypes', (data) => {
+    window.groupNotifyType = {};
+    window.channelNotifyType = {};
+    Object.entries(data || {}).forEach(([gid, info]) => {
+      if (info.notificationType) {
+        window.groupNotifyType[gid] = info.notificationType;
+      }
+      if (info.channelNotificationType) {
+        window.channelNotifyType[gid] = info.channelNotificationType;
+      }
+    });
+  });
+
   socket.on('groupMuted', ({ groupId, muteUntil }) => {
     if (!groupId) return;
     if (muteUntil) {

--- a/test/activeNotifyTypesEmit.test.js
+++ b/test/activeNotifyTypesEmit.test.js
@@ -1,0 +1,42 @@
+const test = require('node:test');
+const assert = require('assert');
+const { EventEmitter } = require('events');
+
+const registerAuthHandlers = require('../controllers/authController');
+
+function query(doc) {
+  return { populate: async () => doc };
+}
+
+function createContext() {
+  const io = { to(){ return { emit: () => {} }; }, sockets:{ sockets: new Map() } };
+  const socket = new EventEmitter();
+  socket.id = 's1';
+  io.sockets.sockets.set('s1', socket);
+
+  const userDoc = { _id: 'u1id', groups: [{ _id: 'g1id', groupId: 'g1' }] };
+  const User = { findOne: async q => q.username === 'u1' ? query(userDoc) : query(null) };
+  const Group = {};
+  const GroupMember = { findOne: async () => ({ notificationType: 'mentions', channelNotificationType: new Map([['c1','nothing']]) }) };
+  const ctx = {
+    User,
+    Group,
+    GroupMember,
+    users: { s1: {} },
+    onlineUsernames: new Set(),
+    groupController: { async sendGroupsListToUser() {} },
+    store: null,
+    userSessions: {}
+  };
+  return { io, socket, ctx };
+}
+
+test('set-username emits activeNotifyTypes info', async () => {
+  const { io, socket, ctx } = createContext();
+  registerAuthHandlers(io, socket, ctx);
+  let emitted;
+  socket.emit = (ev, data) => { if(ev==='activeNotifyTypes') emitted = data; };
+  const handler = socket.listeners('set-username')[0];
+  await handler('u1');
+  assert.deepStrictEqual(emitted, { g1: { notificationType: 'mentions', channelNotificationType: { c1: 'nothing' } } });
+});

--- a/utils/collectNotifyInfo.js
+++ b/utils/collectNotifyInfo.js
@@ -1,0 +1,29 @@
+const getEntries = map => {
+  if (!map) return [];
+  if (typeof map.entries === 'function') return Array.from(map.entries());
+  return Object.entries(map);
+};
+
+async function collectNotifyInfo(username, { User, Group, GroupMember }) {
+  const result = {};
+  try {
+    const userDoc = await User.findOne({ username }).populate('groups');
+    if (!userDoc) return result;
+    await Promise.all(userDoc.groups.map(async g => {
+      const gm = await GroupMember.findOne({ user: userDoc._id, group: g._id })
+        .select('notificationType channelNotificationType');
+      if (!gm) return;
+      const channelEntries = getEntries(gm.channelNotificationType)
+        .filter(([, val]) => typeof val === 'string');
+      result[g.groupId] = {
+        notificationType: gm.notificationType,
+        channelNotificationType: Object.fromEntries(channelEntries)
+      };
+    }));
+  } catch (err) {
+    console.error('collectNotifyInfo error:', err);
+  }
+  return result;
+}
+
+module.exports = collectNotifyInfo;


### PR DESCRIPTION
## Summary
- gather notification preferences with `collectNotifyInfo`
- emit `activeNotifyTypes` during login
- handle notify types on the client
- test new behaviour

## Testing
- `npm test` *(fails: Cannot find module 'bcryptjs')*

------
https://chatgpt.com/codex/tasks/task_e_685a91c33e0c8326a14888969daf7fb2