### PR TITLE
Sync notification state with server events

### DIFF
--- a/public/js/socketEvents.js
+++ b/public/js/socketEvents.js
@@ -943,6 +943,26 @@ export function initSocketEvents(socket) {
     });
   });
 
+  socket.on('groupNotifyTypeUpdated', ({ groupId, type }) => {
+    if (!groupId) return;
+    window.groupNotifyType[groupId] = type;
+    if (window.openNotifyTarget && window.openNotifyType === 'group' &&
+        window.openNotifyTarget.dataset.groupId === groupId) {
+      window.showNotificationSubMenu(window.openNotifyTarget, 'group');
+    }
+  });
+
+  socket.on('channelNotifyTypeUpdated', ({ groupId, channelId, type }) => {
+    if (!groupId || !channelId) return;
+    window.channelNotifyType[groupId] = window.channelNotifyType[groupId] || {};
+    window.channelNotifyType[groupId][channelId] = type;
+    if (window.openNotifyTarget && window.openNotifyType === 'channel' &&
+        window.openNotifyTarget.dataset.channelId === channelId &&
+        window.openNotifyTarget.dataset.groupId === groupId) {
+      window.showNotificationSubMenu(window.openNotifyTarget, 'channel');
+    }
+  });
+
   socket.on('groupMuted', ({ groupId, muteUntil }) => {
     if (!groupId) return;
     if (muteUntil) {


### PR DESCRIPTION
## Summary
- track notify type settings on the client with `groupNotifyType` and `channelNotifyType`
- update context menus to show the currently selected notification setting
- refresh open menus when notify type updates arrive from the server

## Testing
- `npm test` *(fails: Cannot find module 'bcryptjs')*

------
https://chatgpt.com/codex/tasks/task_e_685a9323ae308326ab921a3196b36be6