### PR TITLE
Handle mention-aware notifications

### DIFF
--- a/modules/textChannel.js
+++ b/modules/textChannel.js
@@ -82,7 +82,7 @@ module.exports = function registerTextChannelEvents(io, socket, { Channel, Messa
       // Gönderici hariç tüm kullanıcılara ve aynı zamanda göndericiye de mesajı gönderiyoruz.
       socket.broadcast.to(roomId).emit('newTextMessage', messageData);
       socket.emit('newTextMessage', messageData);
-      await emitChannelUnread(io, groupId, roomId, Group, userSessions, GroupMember, users);
+      await emitChannelUnread(io, groupId, roomId, Group, userSessions, GroupMember, users, mentions);
       await Promise.all(
         mentions.map(u =>
           emitMentionUnread(io, groupId, roomId, u, Group, userSessions, GroupMember, users)

--- a/server.js
+++ b/server.js
@@ -274,6 +274,15 @@ app.post('/api/message', (req, res) => {
         ALLOWED_TAGS: [],
         ALLOWED_ATTR: []
       });
+      const mentionRegex = /@([A-Za-z0-9_]+)/g;
+      const mentions = [];
+      let m;
+      while ((m = mentionRegex.exec(clean))) {
+        const uname = m[1];
+        if (uname && uname !== userDoc.username && !mentions.includes(uname)) {
+          mentions.push(uname);
+        }
+      }
       const msg = new Message({
         channel: channelDoc._id,
         user: userDoc._id,
@@ -302,7 +311,8 @@ app.post('/api/message', (req, res) => {
           Group,
           userSessions,
           GroupMember,
-          users
+          users,
+          mentions
         );
       }
       res.json({ success: true, message: payload });

--- a/test/notifyPrecedence.test.js
+++ b/test/notifyPrecedence.test.js
@@ -1,0 +1,104 @@
+const test = require('node:test');
+const assert = require('assert');
+const emitChannelUnread = require('../utils/emitChannelUnread');
+
+function createContext(opts = {}) {
+  const groupDoc = {
+    _id: 'gid1',
+    groupId: 'g1',
+    users: [{ _id: 'uid1', username: 'u1' }]
+  };
+  const Group = {
+    findOne: async q =>
+      q.groupId === 'g1' ? { populate: async () => groupDoc } : null
+  };
+  const GroupMember = {
+    async findOne() {
+      return {
+        notificationType: opts.notificationType || 'all',
+        channelNotificationType: new Map(
+          Object.entries(opts.channelNotificationType || {})
+        ),
+        muteUntil: undefined,
+        channelMuteUntil: new Map()
+      };
+    },
+    updateOne: async () => {}
+  };
+  const userSessions = { u1: 's1' };
+  const users = { s1: { currentGroup: 'g1', currentTextChannel: 'ch1' } };
+  const io = {
+    emitted: [],
+    to() {
+      return { emit: (ev, p) => this.emitted.push({ ev, p }) };
+    }
+  };
+  return { io, Group, GroupMember, userSessions, users };
+}
+
+test('channel notify override to nothing prevents event', async () => {
+  const ctx = createContext({
+    notificationType: 'all',
+    channelNotificationType: { ch2: 'nothing' }
+  });
+  await emitChannelUnread(
+    ctx.io,
+    'g1',
+    'ch2',
+    ctx.Group,
+    ctx.userSessions,
+    ctx.GroupMember,
+    ctx.users,
+    []
+  );
+  assert.strictEqual(ctx.io.emitted.length, 0);
+});
+
+test('group mentions type requires mention', async () => {
+  const ctx = createContext({ notificationType: 'mentions' });
+  await emitChannelUnread(
+    ctx.io,
+    'g1',
+    'ch2',
+    ctx.Group,
+    ctx.userSessions,
+    ctx.GroupMember,
+    ctx.users,
+    []
+  );
+  assert.strictEqual(ctx.io.emitted.length, 0);
+});
+
+test('group mentions emits when mentioned', async () => {
+  const ctx = createContext({ notificationType: 'mentions' });
+  await emitChannelUnread(
+    ctx.io,
+    'g1',
+    'ch2',
+    ctx.Group,
+    ctx.userSessions,
+    ctx.GroupMember,
+    ctx.users,
+    ['u1']
+  );
+  assert.strictEqual(ctx.io.emitted[0].ev, 'channelUnread');
+});
+
+test('channel notify override to all beats group mentions', async () => {
+  const ctx = createContext({
+    notificationType: 'mentions',
+    channelNotificationType: { ch2: 'all' }
+  });
+  await emitChannelUnread(
+    ctx.io,
+    'g1',
+    'ch2',
+    ctx.Group,
+    ctx.userSessions,
+    ctx.GroupMember,
+    ctx.users,
+    []
+  );
+  assert.strictEqual(ctx.io.emitted.length, 1);
+});
+


### PR DESCRIPTION
## Summary
- send mentioned usernames into `emitChannelUnread`
- allow `emitChannelUnread` to skip users based on notify settings
- parse mentions on REST text message endpoint
- pass mentions when emitting from text channel handler
- test notification precedence logic

## Testing
- `npm test` *(fails: Cannot find module 'bcryptjs')*

------
https://chatgpt.com/codex/tasks/task_e_685aa63d07e08326b64695797a1f4e45