### PR TITLE
Mock select method in GroupMember test helpers

### DIFF
--- a/test/activeMutesEmit.test.js
+++ b/test/activeMutesEmit.test.js
@@ -18,7 +18,12 @@ function createContext() {
   const userDoc = { _id: 'u1id', groups: [{ _id: 'g1id', groupId: 'g1' }] };
   const User = { findOne: async q => q.username === 'u1' ? query(userDoc) : query(null) };
   const Group = {};
-  const GroupMember = { findOne: async () => ({ muteUntil: future, channelMuteUntil: new Map() }) };
+  const GroupMember = {
+    async findOne() {
+      const doc = { muteUntil: future, channelMuteUntil: new Map() };
+      return { select() { return doc; } };
+    }
+  };
   const ctx = {
     User,
     Group,

--- a/test/activeNotifyTypesEmit.test.js
+++ b/test/activeNotifyTypesEmit.test.js
@@ -17,7 +17,12 @@ function createContext() {
   const userDoc = { _id: 'u1id', groups: [{ _id: 'g1id', groupId: 'g1' }] };
   const User = { findOne: async q => q.username === 'u1' ? query(userDoc) : query(null) };
   const Group = {};
-  const GroupMember = { findOne: async () => ({ notificationType: 'mentions', channelNotificationType: new Map([['c1','nothing']]) }) };
+  const GroupMember = {
+    async findOne() {
+      const doc = { notificationType: 'mentions', channelNotificationType: new Map([['c1', 'nothing']]) };
+      return { select() { return doc; } };
+    }
+  };
   const ctx = {
     User,
     Group,

--- a/test/channelUnread.test.js
+++ b/test/channelUnread.test.js
@@ -14,10 +14,15 @@ function createContext(opts = {}) {
   const updates = [];
   const GroupMember = {
     updateOne: async (q, upd) => { updates.push(upd); },
-    findOne: async () => ({
-      muteUntil: opts.muteUntil,
-      channelMuteUntil: new Map(Object.entries(opts.channelMuteUntil || {}))
-    })
+    async findOne() {
+      const doc = {
+        muteUntil: opts.muteUntil,
+        channelMuteUntil: new Map(Object.entries(opts.channelMuteUntil || {})),
+        notificationType: undefined,
+        channelNotificationType: undefined
+      };
+      return { select() { return doc; } };
+    }
   };
   const userSessions = { u1: 's1' };
   const users = { s1: { currentGroup: 'g1', currentTextChannel: 'ch1' } };

--- a/test/mentionUnread.test.js
+++ b/test/mentionUnread.test.js
@@ -17,11 +17,12 @@ function createContext(opts = {}) {
   const GroupMember = {
     async findOne(q) {
       if (q.user === 'uid2') {
-        return {
+        const doc = {
           muteUntil: opts.muteUntil,
           channelMuteUntil: new Map(Object.entries(opts.channelMuteUntil || {})),
           mentionUnreads: new Map(Object.entries(opts.mentionUnreads || {}))
         };
+        return { select() { return doc; } };
       }
       return null;
     },


### PR DESCRIPTION
## Summary
- update GroupMember mocks to emulate `.select()`

## Testing
- `npm test` *(fails: Cannot find module 'uuid' et al.)*

------
https://chatgpt.com/codex/tasks/task_e_685aac575fac832693607e145d1df89e