### PR TITLE
Fix .select method access in utils

### DIFF
--- a/utils/collectMuteInfo.js
+++ b/utils/collectMuteInfo.js
@@ -14,8 +14,11 @@ async function collectMuteInfo(username, { User, Group, GroupMember }) {
     if (!userDoc) return result;
     const now = Date.now();
     await Promise.all(userDoc.groups.map(async g => {
-      const gm = await GroupMember.findOne({ user: userDoc._id, group: g._id })
-        .select('muteUntil channelMuteUntil');
+      let gmQuery = GroupMember.findOne({ user: userDoc._id, group: g._id });
+      if (gmQuery && typeof gmQuery.select === 'function') {
+        gmQuery = gmQuery.select('muteUntil channelMuteUntil');
+      }
+      const gm = await gmQuery;
       if (!gm) return;
       const groupMuteTs = gm.muteUntil instanceof Date ? gm.muteUntil.getTime() : 0;
       const channelMuteEntries = getEntries(gm.channelMuteUntil)

--- a/utils/collectNotifyInfo.js
+++ b/utils/collectNotifyInfo.js
@@ -13,8 +13,11 @@ async function collectNotifyInfo(username, { User, Group, GroupMember }) {
     }
     if (!userDoc) return result;
     await Promise.all(userDoc.groups.map(async g => {
-      const gm = await GroupMember.findOne({ user: userDoc._id, group: g._id })
-        .select('notificationType channelNotificationType');
+      let gmQuery = GroupMember.findOne({ user: userDoc._id, group: g._id });
+      if (gmQuery && typeof gmQuery.select === 'function') {
+        gmQuery = gmQuery.select('notificationType channelNotificationType');
+      }
+      const gm = await gmQuery;
       if (!gm) return;
       const channelEntries = getEntries(gm.channelNotificationType)
         .filter(([, val]) => typeof val === 'string');

--- a/utils/emitChannelUnread.js
+++ b/utils/emitChannelUnread.js
@@ -11,8 +11,11 @@ async function emitChannelUnread(io, groupId, channelId, Group, userSessions, Gr
       const inGroup = sid && users[sid]?.currentGroup === groupId;
       const inChannel = sid && users[sid]?.currentTextChannel === channelId;
 
-      const gm = await GroupMember.findOne({ user: u._id, group: groupDoc._id })
-        .select('muteUntil channelMuteUntil notificationType channelNotificationType');
+      let gmQuery = GroupMember.findOne({ user: u._id, group: groupDoc._id });
+      if (gmQuery && typeof gmQuery.select === 'function') {
+        gmQuery = gmQuery.select('muteUntil channelMuteUntil notificationType channelNotificationType');
+      }
+      const gm = await gmQuery;
       const now = Date.now();
       const groupMuteUntil = gm?.muteUntil instanceof Date ? gm.muteUntil.getTime() : 0;
       let channelMuteUntil;

--- a/utils/emitMentionUnread.js
+++ b/utils/emitMentionUnread.js
@@ -10,8 +10,11 @@ async function emitMentionUnread(io, groupId, channelId, username, Group, userSe
     const sid = userSessions[username];
     const inGroup = sid && users[sid]?.currentGroup === groupId;
     const inChannel = sid && users[sid]?.currentTextChannel === channelId;
-    const gm = await GroupMember.findOne({ user: target._id, group: groupDoc._id })
-      .select('muteUntil channelMuteUntil mentionUnreads');
+    let gmQuery = GroupMember.findOne({ user: target._id, group: groupDoc._id });
+    if (gmQuery && typeof gmQuery.select === 'function') {
+      gmQuery = gmQuery.select('muteUntil channelMuteUntil mentionUnreads');
+    }
+    const gm = await gmQuery;
     const now = Date.now();
     const groupMuteUntil = gm?.muteUntil instanceof Date ? gm.muteUntil.getTime() : 0;
     let channelMuteUntil;


### PR DESCRIPTION
## Summary
- avoid calling `.select` if not present when collecting mute/notify info
- check for `.select` before accessing group member data in `emitChannelUnread` and `emitMentionUnread`

## Testing
- `npm test` *(fails: Cannot find module 'bcryptjs')*

------
https://chatgpt.com/codex/tasks/task_e_685aafac20988326bc2aff5a9a593a92