### PR TITLE
Fix group member query handling

### DIFF
--- a/test/collectNotifyInfo.test.js
+++ b/test/collectNotifyInfo.test.js
@@ -1,0 +1,21 @@
+const test = require('node:test');
+const assert = require('assert');
+const collectNotifyInfo = require('../utils/collectNotifyInfo');
+
+function query(doc){
+  return { populate: async () => doc };
+}
+
+test('collectNotifyInfo collects notification settings', async () => {
+  const userDoc = { _id: 'u1id', groups: [{ _id: 'g1id', groupId: 'g1' }] };
+  const User = { findOne: async q => q.username === 'u1' ? query(userDoc) : query(null) };
+  const Group = {};
+  const GroupMember = {
+    async findOne(){
+      const doc = { notificationType: 'mentions', channelNotificationType: new Map([['c1','nothing']]) };
+      return { select(){ return doc; } };
+    }
+  };
+  const res = await collectNotifyInfo('u1', { User, Group, GroupMember });
+  assert.deepStrictEqual(res, { g1: { notificationType: 'mentions', channelNotificationType: { c1: 'nothing' } } });
+});

--- a/utils/collectMuteInfo.js
+++ b/utils/collectMuteInfo.js
@@ -18,7 +18,10 @@ async function collectMuteInfo(username, { User, Group, GroupMember }) {
       if (gmQuery && typeof gmQuery.select === 'function') {
         gmQuery = gmQuery.select('muteUntil channelMuteUntil');
       }
-      const gm = await gmQuery;
+      let gm = await gmQuery;
+      if (gm && typeof gm.select === 'function') {
+        gm = gm.select('muteUntil channelMuteUntil');
+      }
       if (!gm) return;
       const groupMuteTs = gm.muteUntil instanceof Date ? gm.muteUntil.getTime() : 0;
       const channelMuteEntries = getEntries(gm.channelMuteUntil)

--- a/utils/collectNotifyInfo.js
+++ b/utils/collectNotifyInfo.js
@@ -17,7 +17,10 @@ async function collectNotifyInfo(username, { User, Group, GroupMember }) {
       if (gmQuery && typeof gmQuery.select === 'function') {
         gmQuery = gmQuery.select('notificationType channelNotificationType');
       }
-      const gm = await gmQuery;
+      let gm = await gmQuery;
+      if (gm && typeof gm.select === 'function') {
+        gm = gm.select('notificationType channelNotificationType');
+      }
       if (!gm) return;
       const channelEntries = getEntries(gm.channelNotificationType)
         .filter(([, val]) => typeof val === 'string');

--- a/utils/emitChannelUnread.js
+++ b/utils/emitChannelUnread.js
@@ -15,7 +15,10 @@ async function emitChannelUnread(io, groupId, channelId, Group, userSessions, Gr
       if (gmQuery && typeof gmQuery.select === 'function') {
         gmQuery = gmQuery.select('muteUntil channelMuteUntil notificationType channelNotificationType');
       }
-      const gm = await gmQuery;
+      let gm = await gmQuery;
+      if (gm && typeof gm.select === 'function') {
+        gm = gm.select('muteUntil channelMuteUntil notificationType channelNotificationType');
+      }
       const now = Date.now();
       const groupMuteUntil = gm?.muteUntil instanceof Date ? gm.muteUntil.getTime() : 0;
       let channelMuteUntil;

--- a/utils/emitMentionUnread.js
+++ b/utils/emitMentionUnread.js
@@ -14,7 +14,10 @@ async function emitMentionUnread(io, groupId, channelId, username, Group, userSe
     if (gmQuery && typeof gmQuery.select === 'function') {
       gmQuery = gmQuery.select('muteUntil channelMuteUntil mentionUnreads');
     }
-    const gm = await gmQuery;
+    let gm = await gmQuery;
+    if (gm && typeof gm.select === 'function') {
+      gm = gm.select('muteUntil channelMuteUntil mentionUnreads');
+    }
     const now = Date.now();
     const groupMuteUntil = gm?.muteUntil instanceof Date ? gm.muteUntil.getTime() : 0;
     let channelMuteUntil;


### PR DESCRIPTION
## Summary
- fix `GroupMember.findOne` handling in collect utils
- handle query objects in unread emitters
- add tests for `collectNotifyInfo`

## Testing
- `npm test` *(fails: Cannot find module 'uuid')*

------
https://chatgpt.com/codex/tasks/task_e_685ab34cac9883269e4e1a35f92face5