### PR TITLE
Allow clearing stored phone numbers

### DIFF
--- a/public/js/userSettings.js
+++ b/public/js/userSettings.js
@@ -432,7 +432,12 @@ function initAccountSection() {
   if (confirmRemovePhone) confirmRemovePhone.addEventListener('click', () => {
     const phoneVal = document.querySelector('#phoneRow .info-value');
     if (phoneVal) phoneVal.textContent = '—';
-    // TODO: remove phone on server
+    const uname = localStorage.getItem('username');
+    fetch(`/api/user/me?username=${encodeURIComponent(uname)}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ field: 'phone', value: '' })
+    }).catch(() => {});
     closeModal('removePhoneConfirmModal');
   });
   const editProfileBtn = document.querySelector('.edit-profile-btn');

--- a/server.js
+++ b/server.js
@@ -174,6 +174,8 @@ app.patch('/api/user/me', async (req, res) => {
       user.username = newName;
     } else if (field === 'displayName') {
       user.name = value;
+    } else if (field === 'phone' && (value === '' || value === null || value === undefined)) {
+      user.phone = undefined;
     } else {
       user[field] = value;
     }

--- a/test/clearPhoneRoute.test.js
+++ b/test/clearPhoneRoute.test.js
@@ -1,0 +1,39 @@
+const test = require('node:test');
+const assert = require('assert');
+
+function loadServer(User) {
+  const originalSetInterval = global.setInterval;
+  global.setInterval = () => ({ unref() {} });
+
+  delete require.cache[require.resolve('../models/User')];
+  require.cache[require.resolve('../models/User')] = { exports: User };
+  delete require.cache[require.resolve('../server')];
+  const serverModule = require('../server');
+
+  global.setInterval = originalSetInterval;
+  return serverModule;
+}
+
+test('PATCH /api/user/me clears phone', async () => {
+  process.env.NODE_ENV = 'test';
+  let saved = false;
+  const userDoc = { username: 'alice', phone: '123', async save() { saved = true; } };
+  const User = { async findOne(q) { return q.username === 'alice' ? userDoc : null; } };
+  const serverModule = loadServer(User);
+  const app = serverModule.app;
+  const srv = app.listen(0);
+  const port = srv.address().port;
+
+  const res = await fetch(`http://localhost:${port}/api/user/me?username=alice`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ field: 'phone', value: '' })
+  });
+  await res.json();
+
+  assert.strictEqual(res.status, 200);
+  assert.ok(saved);
+  assert.strictEqual(userDoc.phone, undefined);
+
+  srv.close();
+});

--- a/test/removePhoneClient.test.js
+++ b/test/removePhoneClient.test.js
@@ -1,0 +1,57 @@
+const test = require('node:test');
+const assert = require('assert');
+const { JSDOM } = require('jsdom');
+
+async function setup() {
+  const dom = new JSDOM(`<!doctype html>
+    <div id="userSettingsPage">
+      <div class="settings-main-container">
+        <div class="settings-panel">
+          <aside class="settings-sidebar">
+            <ul class="settings-menu">
+              <li class="active" data-section="account">Hesabım</li>
+            </ul>
+          </aside>
+          <div class="settings-content"></div>
+        </div>
+      </div>
+    </div>
+    <div id="callScreen"></div>
+    <div id="removePhoneConfirmModal">
+      <button id="confirmRemovePhoneBtn"></button>
+      <button id="cancelRemovePhoneBtn"></button>
+      <span id="closeRemovePhoneConfirmModal"></span>
+    </div>`);
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.closeModal = () => {};
+  global.openModal = () => {};
+  window.Cropper = function(){};
+  window.loadAvatar = async () => '';
+  const calls = [];
+  global.fetch = async (url, opts) => {
+    if (!opts) {
+      return { ok: true, json: async () => ({ displayName:'d', username:'alice', email:'e', phone:'555' }) };
+    }
+    calls.push({ url, opts });
+    return { ok: true, json: async () => ({}) };
+  };
+  window.localStorage.setItem('username', 'alice');
+  const mod = await import('../public/js/userSettings.js');
+  return { mod, calls, dom };
+}
+
+test('confirm remove phone updates UI and sends request', async () => {
+  const { mod, calls } = await setup();
+  mod.openUserSettings();
+  await new Promise(r => setTimeout(r, 0));
+  const phoneVal = document.querySelector('#phoneRow .info-value');
+  assert.strictEqual(phoneVal.textContent, '555');
+  document.getElementById('confirmRemovePhoneBtn').click();
+  await new Promise(r => setTimeout(r, 0));
+  assert.strictEqual(phoneVal.textContent, '—');
+  assert.strictEqual(calls.length, 1);
+  assert.ok(calls[0].url.includes('/api/user/me?username=alice'));
+  const body = JSON.parse(calls[0].opts.body);
+  assert.deepStrictEqual(body, { field: 'phone', value: '' });
+});


### PR DESCRIPTION
## Summary
- send a request when removing a phone number
- clear phone field server-side when value is empty
- test UI patch request and server behaviour

## Testing
- `npm test` *(fails: Cannot find module 'bcryptjs')*

------
https://chatgpt.com/codex/tasks/task_e_685abf60642c83269a595b93ec155277