### PR TITLE
Update TURN configuration to rely solely on env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 MONGODB_URI=mongodb://localhost:27017/test
 PORT=3000
 ANNOUNCED_IP=
+# Credentials for TURN server (optional). If left blank, TURN servers will not be used.
 TURN_USERNAME=
 TURN_CREDENTIAL=
 SOCKET_URL=

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ This project contains the backend and frontend assets for a WebSocket-based chat
   - `MONGODB_URI` – MongoDB connection string
   - `PORT` – (optional) server port, defaults to `3000`
   - `ANNOUNCED_IP` – (optional) public IP for mediasoup
-  - `TURN_USERNAME` and `TURN_CREDENTIAL` – (optional) credentials for TURN servers
+  - `TURN_USERNAME` and `TURN_CREDENTIAL` – credentials for the bundled TURN
+    servers. If omitted the TURN servers are skipped and only a public STUN
+    server is used.
   - `SOCKET_URL` – (optional) base URL for the Socket.IO server. Defaults to
     `window.location.origin` if omitted.
     

--- a/sfu.js
+++ b/sfu.js
@@ -121,34 +121,43 @@ async function createWebRtcTransport(router) {
 
     /**
      * STUN/TURN sunucularını buraya ekliyoruz:
-     * .env'de TURN_USERNAME / TURN_CREDENTIAL tanımlanmadıysa varsayılan değerler kullanılır.
+     * TURN bilgileri sadece TURN_USERNAME ve TURN_CREDENTIAL tanımlıysa eklenir.
      */
-    iceServers: [
-      {
-        urls: 'stun:stun.l.google.com:19302'
-      },
+  };
+
+  const iceServers = [
+    {
+      urls: 'stun:stun.l.google.com:19302'
+    }
+  ];
+
+  if (process.env.TURN_USERNAME && process.env.TURN_CREDENTIAL) {
+    iceServers.push(
       {
         urls: 'turn:global.relay.metered.ca:80',
-        username: process.env.TURN_USERNAME || '6975c20c80cb0d79f1e4a4b6',
-        credential: process.env.TURN_CREDENTIAL || 'BCHrcOSfdcmZ/Dda'
+        username: process.env.TURN_USERNAME,
+        credential: process.env.TURN_CREDENTIAL
       },
       {
         urls: 'turn:global.relay.metered.ca:80?transport=tcp',
-        username: process.env.TURN_USERNAME || '6975c20c80cb0d79f1e4a4b6',
-        credential: process.env.TURN_CREDENTIAL || 'BCHrcOSfdcmZ/Dda'
+        username: process.env.TURN_USERNAME,
+        credential: process.env.TURN_CREDENTIAL
       },
       {
         urls: 'turn:global.relay.metered.ca:443',
-        username: process.env.TURN_USERNAME || '6975c20c80cb0d79f1e4a4b6',
-        credential: process.env.TURN_CREDENTIAL || 'BCHrcOSfdcmZ/Dda'
+        username: process.env.TURN_USERNAME,
+        credential: process.env.TURN_CREDENTIAL
       },
       {
         urls: 'turns:global.relay.metered.ca:443?transport=tcp',
-        username: process.env.TURN_USERNAME || '6975c20c80cb0d79f1e4a4b6',
-        credential: process.env.TURN_CREDENTIAL || 'BCHrcOSfdcmZ/Dda'
+        username: process.env.TURN_USERNAME,
+        credential: process.env.TURN_CREDENTIAL
       }
-    ]
-  };
+    );
+  }
+
+  transportOptions.iceServers = iceServers;
+
 
   const transport = await router.createWebRtcTransport(transportOptions);
   return transport;


### PR DESCRIPTION
## Summary
- load TURN credentials from environment variables only
- document TURN variables
- clarify TURN usage in README

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_e_685ac12593a88326ab90723e2666c1b7