### PR TITLE
Fix missing module import

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -55,7 +55,6 @@ function clearScreenShareUI() {
 }
 window.clearScreenShareUI = clearScreenShareUI;
 
-import logger from '../utils/logger.js';
 import * as TextChannel from './js/textChannel.js';
 import * as ScreenShare from './js/screenShare.js';
 import { initTypingIndicator } from './js/typingIndicator.js';
@@ -510,7 +509,7 @@ window.addEventListener('DOMContentLoaded', () => {
   document.addEventListener('click', function(e) {
     if(e.target && e.target.classList.contains('dm-filter-item')) {
       const filter = e.target.getAttribute('data-filter');
-      logger.info('DM Filter clicked: ' + filter);
+      console.info('DM Filter clicked: ' + filter);
     }
   });
 });


### PR DESCRIPTION
## Summary
- remove server-side logger dependency in the browser code
- use `console.info` for the debug message

## Testing
- `npm test` *(fails: Cannot find module 'uuid')*
- `bash setup.sh` *(fails to install packages: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685ac6ad69e883269f809e4fc97532ea