### PR TITLE
Add client logger module

### DIFF
--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -1,4 +1,4 @@
-import logger from '../../utils/logger.js';
+import logger from '../utils/logger.js';
 
 export function attemptRegister(socket, elements) {
   const {

--- a/public/js/screenShare.js
+++ b/public/js/screenShare.js
@@ -1,6 +1,6 @@
 // public/js/screenShare.js
 
-import logger from '../../utils/logger.js';
+import logger from '../utils/logger.js';
 
 /**
  * Bu modül, ekran paylaşımını başlatıp durdurmak için gerekli fonksiyonları sağlar.

--- a/public/js/socketEvents.js
+++ b/public/js/socketEvents.js
@@ -2,7 +2,7 @@ import * as UserList from './userList.js';
 import * as WebRTC from './webrtc.js';
 import { startVolumeAnalysis } from './audioUtils.js';
 import * as Ping from './ping.js';
-import logger from '../../utils/logger.js';
+import logger from '../utils/logger.js';
 
 // Holds latest channel data so that we can re-render user lists when needed
 window.latestChannelsData = null;

--- a/public/js/webrtc.js
+++ b/public/js/webrtc.js
@@ -1,7 +1,7 @@
 import * as ScreenShare from "./screenShare.js";
 import { startVolumeAnalysis, stopVolumeAnalysis } from './audioUtils.js';
 import * as Ping from './ping.js';
-import logger from '../../utils/logger.js';
+import logger from '../utils/logger.js';
 
 export let device = null;   // mediasoup-client Device
 export let deviceIsLoaded = false;

--- a/public/utils/logger.js
+++ b/public/utils/logger.js
@@ -1,0 +1,5 @@
+export default {
+  info:  (...args) => console.info(...args),
+  warn:  (...args) => console.warn(...args),
+  error: (...args) => console.error(...args)
+};


### PR DESCRIPTION
## Summary
- implement a small logger for the web client
- fix relative imports in front‑end modules

## Testing
- `npm test` *(fails: Cannot find module 'bcryptjs')*

------
https://chatgpt.com/codex/tasks/task_e_685ac7d740208326a91c91ee697368a4