### PR TITLE
Add warn log for unknown groupId

### DIFF
--- a/controllers/groupController.js
+++ b/controllers/groupController.js
@@ -121,7 +121,10 @@ function broadcastAllChannelsData(io, users, groups, groupId) {
 
 async function sendRoomsListToUser(io, socketId, context, groupId) {
   const { groups, users, Group, User, GroupMember } = context;
-  if (!groups[groupId]) return;
+  if (!groups[groupId]) {
+    logger.warn(`sendRoomsListToUser: unknown groupId ${groupId}`);
+    return;
+  }
   let channelUnreads = {};
   if (users && Group && User && GroupMember) {
     try {


### PR DESCRIPTION
## Summary
- warn if `sendRoomsListToUser` receives a missing groupId

## Testing
- `npm test` *(fails: Cannot find module 'bcryptjs')*

------
https://chatgpt.com/codex/tasks/task_e_685ae582e2dc832687ba0a106e09ce0a