### PR TITLE
Handle socket error messages with toast

### DIFF
--- a/public/js/socketEvents.js
+++ b/public/js/socketEvents.js
@@ -588,6 +588,10 @@ export function initSocketEvents(socket) {
       registerErrorMessage.style.display = 'block';
     }
   });
+  socket.on('errorMessage', (msg) => {
+    if (typeof showToast === 'function') showToast(msg);
+    else alert(msg);
+  });
   socket.on('groupUsers', (data) => {
     UserList.updateUserList(data);
   });

--- a/public/js/userSettings.js
+++ b/public/js/userSettings.js
@@ -129,6 +129,9 @@ function showToast(msg) {
   setTimeout(() => { t.style.display = 'none'; }, 2000);
 }
 
+// Expose toast helper globally for modules loaded later
+window.showToast = showToast;
+
 
 function openEditUsernameModal() {
   const modal = document.getElementById('editUsernameModal');


### PR DESCRIPTION
## Summary
- expose `showToast` globally for other scripts
- handle `errorMessage` events in `socketEvents`

## Testing
- `npm test` *(fails: Cannot find module 'bcryptjs')*

------
https://chatgpt.com/codex/tasks/task_e_685ae733b1e883269f901a08d889bcec