### PR TITLE
Add warning when DB contains no groups

### DIFF
--- a/controllers/groupController.js
+++ b/controllers/groupController.js
@@ -31,7 +31,12 @@ async function loadGroupsFromDB({ Group, groups }) {
       groups[g.groupId] = { owner: ownerName, name: g.name, users: [], rooms: {} };
       store.setJSON(store.key('group', g.groupId), groups[g.groupId]);
     });
-    logger.info('loadGroupsFromDB tamam, groups:', Object.keys(groups));
+    const groupKeys = Object.keys(groups);
+    if (groupKeys.length === 0) {
+      logger.warn('No groups found in MongoDB. Channels will not be available.');
+    } else {
+      logger.info('loadGroupsFromDB tamam, groups:', groupKeys);
+    }
   } catch (err) {
     console.error('loadGroupsFromDB hata:', err);
   }


### PR DESCRIPTION
## Summary
- warn if MongoDB returns no groups

## Testing
- `npm test` *(fails: Cannot find module 'uuid', 'dotenv', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685aeb58ba908326b3a7f7a49a5cb7a7