### PR TITLE
Add category support in group controller

### DIFF
--- a/server.js
+++ b/server.js
@@ -22,6 +22,7 @@ const { connectToDatabase } = require('./config/database');
 const User = require('./models/User');
 const Group = require('./models/Group');
 const Channel = require('./models/Channel');
+const Category = require('./models/Category');
 const Message = require('./models/Message');
 const DMMessage = require('./models/DmMessage');
 const GroupMember = require('./models/GroupMember');
@@ -81,11 +82,12 @@ async function startServer() {
     await sfu.createWorkers();
     logger.info("Mediasoup Workers hazır!");
     await groupController.loadGroupsFromDB({ Group, groups });
+    const catCount = await groupController.loadCategoriesFromDB({ Category, groups });
     const chCount = await groupController.loadChannelsFromDB({ Channel, groups });
     const grpCount = Object.keys(groups).length;
     const totalCh = Object.values(groups).reduce((a,g)=>a+Object.keys(g.rooms).length,0);
     const channelsLoaded = chCount || totalCh;
-    logger.info(`Startup: groups=${grpCount}, channels=${channelsLoaded}`);
+    logger.info(`Startup: groups=${grpCount}, categories=${catCount}, channels=${channelsLoaded}`);
     logger.info("Uygulama başlangıç yüklemeleri tamam.");
 
     server.listen(PORT, () => {
@@ -361,7 +363,7 @@ app.get('/debug/group-channel-count', (req, res) => {
   const channelCount = Object.values(groups).reduce((a, g) => a + Object.keys(g.rooms).length, 0);
   res.json({ groupCount, channelCount });
 });
-const context = { User, Group, Channel, Message, DMMessage, GroupMember, users, groups, onlineUsernames, userSessions, friendRequests, sfu, groupController, store };
+const context = { User, Group, Channel, Category, Message, DMMessage, GroupMember, users, groups, onlineUsernames, userSessions, friendRequests, sfu, groupController, store };
 
 io.on("connection", (socket) => {
   logger.info(`Yeni bağlantı: ${socket.id}`);

--- a/test/categoryActions.test.js
+++ b/test/categoryActions.test.js
@@ -1,0 +1,50 @@
+const test = require('node:test');
+const assert = require('assert');
+const { EventEmitter } = require('events');
+
+const groupController = require('../controllers/groupController');
+
+function createContext() {
+  const users = {};
+  const groups = { group1: { owner: 'u1', name: 'g', users: [], rooms: { chan1: { name: 'Ch', type: 'text', users: [], order: 0, categoryId: null } }, categories: {} } };
+  const categoryStore = {};
+  const channelStore = { chan1: { channelId: 'chan1', group: { groupId: 'group1' } } };
+  const Category = {
+    async findOne(q) { const c = categoryStore[q.categoryId]; return c ? { ...c, group: { groupId: 'group1' } } : null; },
+    async findOneAndUpdate(q,u){ const c=categoryStore[q.categoryId]; if(c){ if(u.name!==undefined) c.name=u.name; if(u.order!==undefined) c.order=u.order; return { ...c, group:{groupId:'group1'} }; } return null; },
+    async findOneAndDelete(q){ if(categoryStore[q.categoryId]){ const res={...categoryStore[q.categoryId], group:{groupId:'group1'}}; delete categoryStore[q.categoryId]; return res;} return null; },
+    async create(data){ categoryStore[data.categoryId]={...data}; }
+  };
+  const Channel = {
+    async findOneAndUpdate(q, u){ channelStore[q.channelId] = { ...channelStore[q.channelId], ...u }; return channelStore[q.channelId]; }
+  };
+  return { users, groups, Category, Channel, categoryStore, channelStore };
+}
+
+test('createCategory adds category to memory', async () => {
+  const socket = new EventEmitter();
+  const io = { emitted: [], to(room){ return { emit:(ev,p)=>io.emitted.push({room,ev,p}) }; } };
+  const ctx = createContext();
+  groupController.register(io, socket, { users: ctx.users, groups: ctx.groups, User:{}, Group:{}, Channel: ctx.Channel, Category: ctx.Category, onlineUsernames:new Set(), GroupMember:{} });
+  const handler = socket.listeners('createCategory')[0];
+  await handler({ groupId:'group1', name:'Cat' });
+  const cid = Object.keys(ctx.groups.group1.categories)[0];
+  assert.ok(cid);
+  assert.strictEqual(ctx.groups.group1.categories[cid].name, 'Cat');
+  assert.ok(io.emitted.find(e=>e.ev==='roomsList'));
+});
+
+test('assignChannelCategory updates channel', async () => {
+  const socket = new EventEmitter();
+  const io = { emitted: [], to(room){ return { emit:(ev,p)=>io.emitted.push({room,ev,p}) }; } };
+  const ctx = createContext();
+  ctx.groups.group1.categories.cat1 = { name: 'C1', order:0 };
+  ctx.categoryStore.cat1 = { categoryId:'cat1', name:'C1', group:{ groupId:'group1' }, order:0 };
+  // But we inserted property this way; we need to ensure Category.findOne works
+  ctx.Category.findOne = async (q)=> q.categoryId==='cat1'?{ categoryId:'cat1', name:'C1', group:{groupId:'group1'} } : null;
+  groupController.register(io, socket, { users: ctx.users, groups: ctx.groups, User:{}, Group:{}, Channel: ctx.Channel, Category: ctx.Category, onlineUsernames:new Set(), GroupMember:{} });
+  const handler = socket.listeners('assignChannelCategory')[0];
+  await handler({ groupId:'group1', channelId:'chan1', categoryId:'cat1' });
+  assert.strictEqual(ctx.groups.group1.rooms.chan1.categoryId, 'cat1');
+  assert.ok(io.emitted.find(e=>e.ev==='roomsList'));
+});


### PR DESCRIPTION
## Summary
- support channel categories in the group controller
- load categories on startup
- broadcast categories with channels to clients
- handle creating/renaming/deleting/reordering categories and assigning channels
- add tests for new category operations

## Testing
- `npm test` *(fails: Cannot find module 'bcryptjs')*

------
https://chatgpt.com/codex/tasks/task_e_685b104a90c0832688a7192165ff5e8a