### PR TITLE
Add tests for channel categories

### DIFF
--- a/test/categoryActions.test.js
+++ b/test/categoryActions.test.js
@@ -48,3 +48,48 @@ test('assignChannelCategory updates channel', async () => {
   assert.strictEqual(ctx.groups.group1.rooms.chan1.categoryId, 'cat1');
   assert.ok(io.emitted.find(e=>e.ev==='roomsList'));
 });
+
+test('createCategory persists to store', async () => {
+  const socket = new EventEmitter();
+  const io = { emitted: [], to(room){ return { emit:(ev,p)=>io.emitted.push({room,ev,p}) }; } };
+  const ctx = createContext();
+  groupController.register(io, socket, { users: ctx.users, groups: ctx.groups, User:{}, Group:{}, Channel: ctx.Channel, Category: ctx.Category, onlineUsernames:new Set(), GroupMember:{} });
+  const handler = socket.listeners('createCategory')[0];
+  await handler({ groupId:'group1', name:'Persist' });
+  const cid = Object.keys(ctx.categoryStore)[0];
+  assert.ok(cid);
+  assert.strictEqual(ctx.categoryStore[cid].name, 'Persist');
+});
+
+test('assignChannelCategory persists update to channel store', async () => {
+  const socket = new EventEmitter();
+  const io = { emitted: [], to(room){ return { emit:(ev,p)=>io.emitted.push({room,ev,p}) }; } };
+  const ctx = createContext();
+  ctx.groups.group1.categories.cat1 = { name: 'C1', order:0 };
+  ctx.categoryStore.cat1 = { categoryId:'cat1', name:'C1', group:{ groupId:'group1' }, _id:'doc1', order:0 };
+  ctx.Category.findOne = async (q)=> q.categoryId==='cat1'?{ _id:'doc1', categoryId:'cat1', group:{groupId:'group1'} } : null;
+  groupController.register(io, socket, { users: ctx.users, groups: ctx.groups, User:{}, Group:{}, Channel: ctx.Channel, Category: ctx.Category, onlineUsernames:new Set(), GroupMember:{} });
+  const handler = socket.listeners('assignChannelCategory')[0];
+  await handler({ groupId:'group1', channelId:'chan1', categoryId:'cat1' });
+  assert.strictEqual(ctx.channelStore.chan1.category, 'doc1');
+  assert.strictEqual(ctx.groups.group1.rooms.chan1.categoryId, 'cat1');
+  assert.ok(io.emitted.find(e=>e.ev==='roomsList'));
+});
+
+test('reorderCategory updates order and emits roomsList', async () => {
+  const socket = new EventEmitter();
+  const io = { emitted: [], to(room){ return { emit:(ev,p)=>io.emitted.push({room,ev,p}) }; } };
+  const ctx = createContext();
+  ctx.groups.group1.categories.cat1 = { name:'C1', order:0 };
+  ctx.groups.group1.categories.cat2 = { name:'C2', order:1 };
+  ctx.categoryStore.cat1 = { categoryId:'cat1', name:'C1', group:{groupId:'group1'}, order:0 };
+  ctx.categoryStore.cat2 = { categoryId:'cat2', name:'C2', group:{groupId:'group1'}, order:1 };
+  groupController.register(io, socket, { users: ctx.users, groups: ctx.groups, User:{}, Group:{}, Channel: ctx.Channel, Category: ctx.Category, onlineUsernames:new Set(), GroupMember:{} });
+  const handler = socket.listeners('reorderCategory')[0];
+  await handler({ groupId:'group1', categoryId:'cat2', newIndex:0 });
+  assert.strictEqual(ctx.groups.group1.categories.cat2.order, 0);
+  assert.strictEqual(ctx.groups.group1.categories.cat1.order, 1);
+  assert.strictEqual(ctx.categoryStore.cat2.order, 0);
+  assert.strictEqual(ctx.categoryStore.cat1.order, 1);
+  assert.ok(io.emitted.find(e=>e.ev==='roomsList'));
+});

--- a/test/categoryCollapse.test.js
+++ b/test/categoryCollapse.test.js
@@ -1,0 +1,42 @@
+const test = require('node:test');
+const assert = require('assert');
+const { EventEmitter } = require('events');
+
+const groupController = require('../controllers/groupController');
+const collectCategoryPrefs = require('../utils/collectCategoryPrefs');
+
+function createContext() {
+  const io = { emitted: [], to(id){ return { emit:(ev,p)=>io.emitted.push({id,ev,p}) }; }, sockets:{ sockets:new Map() } };
+  const socket = new EventEmitter();
+  socket.id = 's1';
+  io.sockets.sockets.set('s1', socket);
+
+  const users = { s1: { username: 'u1' } };
+  const groups = { g1: { owner:'u1', name:'g', users:[], rooms:{}, categories:{ cat1:{ name:'C1', order:0 } } } };
+
+  const userDoc = { _id:'uid1', username:'u1', groups:[{ _id:'gid1', groupId:'g1' }] };
+  const groupDoc = { _id:'gid1', groupId:'g1' };
+
+  const updates = [];
+  const GroupMember = {
+    doc: { collapsedCategories: new Map() },
+    async updateOne(filter, upd){ updates.push(upd); if(upd.$set){ for(const k of Object.keys(upd.$set)){ const cid = k.split('.').slice(1).join('.'); this.doc.collapsedCategories.set(cid, upd.$set[k]); } } },
+    async findOne(){ return { select: () => this.doc }; }
+  };
+  const User = { findOne: async q => q.username==='u1' ? userDoc : null };
+  const Group = { findOne: async q => q.groupId==='g1' ? groupDoc : null };
+
+  return { io, socket, context:{ users, groups, User, Group, Channel:{}, Category:{}, GroupMember, onlineUsernames:new Set() }, updates, User, Group, GroupMember };
+}
+
+test('collapsed state stored and restored on reconnect', async () => {
+  const { io, socket, context, updates, User, Group, GroupMember } = createContext();
+  groupController.register(io, socket, context);
+  const handler = socket.listeners('setCategoryCollapsed')[0];
+  await handler({ groupId:'g1', categoryId:'cat1', collapsed:true });
+  assert.deepStrictEqual(updates[0], { $set: { 'collapsedCategories.cat1': true } });
+  assert.ok(io.emitted.find(e=>e.ev==='categoryCollapseUpdated'));
+
+  const prefs = await collectCategoryPrefs('u1', { User, Group, GroupMember });
+  assert.deepStrictEqual(prefs, { g1: { categoryOrder: {}, collapsedCategories: { cat1: true } } });
+});


### PR DESCRIPTION
## Summary
- extend `categoryActions.test.js` with coverage for persistence and reordering
- add `categoryCollapse.test.js` to verify collapsed category state persistence

## Testing
- `npm test` *(fails: Cannot find module 'bcryptjs')*

------
https://chatgpt.com/codex/tasks/task_e_685b16eb911c83268a47f6d380397f53