### PR TITLE
Fix channel drop on collapsed category

### DIFF
--- a/public/js/socketEvents.js
+++ b/public/js/socketEvents.js
@@ -1326,6 +1326,9 @@ export function initSocketEvents(socket) {
     header.addEventListener('drop', (e) => {
       if (!draggedChannelEl || !channelPlaceholder) return;
       e.preventDefault();
+      if (channelPlaceholder.parentNode !== channelContainer) {
+        channelContainer.appendChild(channelPlaceholder);
+      }
       channelContainer.insertBefore(draggedChannelEl, channelPlaceholder);
       const items = Array.from(roomListDiv.querySelectorAll('.channel-item'));
       const newIndex = items.indexOf(draggedChannelEl);


### PR DESCRIPTION
## Summary
- check placeholder parent before inserting channel when dropping on a category header

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_e_685bd5df799c832695cfbeec37b8fcc7