### PR TITLE
Fix drag-and-drop DOMException

### DIFF
--- a/public/js/socketEvents.js
+++ b/public/js/socketEvents.js
@@ -1329,7 +1329,9 @@ export function initSocketEvents(socket) {
       if (channelPlaceholder.parentNode !== channelContainer) {
         channelContainer.appendChild(channelPlaceholder);
       }
-      channelContainer.insertBefore(draggedChannelEl, channelPlaceholder);
+      if (channelPlaceholder.parentNode === channelContainer) {
+        channelContainer.insertBefore(draggedChannelEl, channelPlaceholder);
+      }
       const items = Array.from(roomListDiv.querySelectorAll('.channel-item'));
       const newIndex = items.indexOf(draggedChannelEl);
       hideChannelPreview();


### PR DESCRIPTION
## Summary
- guard channel drop handler when moving channels into collapsed categories

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_e_685bd7399e888326b705ca2ea9cad590