### PR TITLE
Fix invalid destructuring that caused syntax error

### DIFF
--- a/public/js/uiEvents.js
+++ b/public/js/uiEvents.js
@@ -68,8 +68,11 @@ export function initUIEvents(socket, attemptLogin, attemptRegister) {
     modalCategoryName,
     modalCreateCategoryBtn,
     modalCloseCategoryBtn,
-    createChannelTargetCategory: null,
+    createChannelTargetCategory,
   } = window;
+
+  // ensure this helper value exists for later use
+  window.createChannelTargetCategory ??= null;
 
   Mentions.initMentions(socket);
 


### PR DESCRIPTION
## Summary
- avoid using `null` as a destructuring alias in `uiEvents.js`
- initialize `window.createChannelTargetCategory` if missing

## Testing
- `npm test` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685be68c913c83268934020cd81fec1b