### PR TITLE
Fix test context to include categories

### DIFF
--- a/test/channelActions.test.js
+++ b/test/channelActions.test.js
@@ -7,7 +7,7 @@ const groupController = require('../controllers/groupController');
 function createContext() {
   const users = {};
   const groups = {
-    group1: { owner: 'u1', name: 'g', users: [], rooms: { chan1: { name: 'Old', type: 'text', users: [], order: 0 } } }
+    group1: { owner: 'u1', name: 'g', users: [], rooms: { chan1: { name: 'Old', type: 'text', users: [], order: 0 } }, categories: {} }
   };
   const channelStore = {
     chan1: { channelId: 'chan1', name: 'Old', group: { groupId: 'group1' }, order: 0 }
@@ -43,6 +43,7 @@ function createContext() {
 
 function createContextWithTwoChannels() {
   const ctx = createContext();
+  ctx.groups.group1.categories = {};
   ctx.groups.group1.rooms.chan2 = { name: 'Other', type: 'text', users: [], order: 1 };
   ctx.channelStore.chan2 = { channelId: 'chan2', name: 'Other', group: { groupId: 'group1' }, order: 1 };
   return ctx;

--- a/test/createChannel.test.js
+++ b/test/createChannel.test.js
@@ -6,7 +6,7 @@ const groupController = require('../controllers/groupController');
 
 function createContext() {
   const users = { sock1: { username: 'u1' } };
-  const groups = { group1: { owner: 'u1', name: 'g', users: [], rooms: {} } };
+  const groups = { group1: { owner: 'u1', name: 'g', users: [], rooms: {}, categories: {} } };
   const savedChannels = {};
   const Group = { async findOne(q) { return q.groupId === 'group1' ? { groupId: 'group1', _id: 'gid' } : null; } };
   class Channel {


### PR DESCRIPTION
## Summary
- ensure group mocks in tests include `categories` field

## Testing
- `npm test` *(fails: Cannot find module 'bcryptjs')*

------
https://chatgpt.com/codex/tasks/task_e_685c08b092fc8326a3b36f2e29bdfbcd