### PR TITLE
Fix group unread persist test imports

### DIFF
--- a/test/groupUnreadPersist.test.js
+++ b/test/groupUnreadPersist.test.js
@@ -23,8 +23,10 @@ async function setup() {
   window.showChannelStatusPanel = () => {};
   window.textMessages = document.createElement('div');
   const mod = await import('../public/js/socketEvents.js');
+  const textMod = await import('../public/js/textChannel.js');
   const socket = new EventEmitter();
   mod.initSocketEvents(socket);
+  textMod.initTextChannelEvents(socket, window.textMessages);
   return { socket };
 }
 


### PR DESCRIPTION
## Summary
- import `textChannel.js` in group unread dot persistance test
- call `initTextChannelEvents` during setup

## Testing
- `npm test` *(fails: cannot find module 'bcryptjs')*
- `node --test test/groupUnreadPersist.test.js` *(fails: cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_685c0cfec3588326ba06066055077bb3