### PR TITLE
Clarify module system used

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ The client-side code under `public/js` is organized into small ES modules:
 - **audioUtils.js** – volume analysis and audio state utilities
 - **uiEvents.js** – sets up DOM event listeners
 
+### Module Style
+
+The Node.js backend uses the CommonJS module system with `require` and
+`module.exports`. Browser code in `public/js` is written as ES modules and is
+loaded using `<script type="module">`.
+
 ### Channel Management
 
 Right-click a channel name in the rooms list to rename or delete it. Selecting


### PR DESCRIPTION
## Summary
- note in the README that the Node server uses CommonJS while the browser code is ES modules

## Testing
- `npm test` *(fails: Cannot find module 'bcryptjs')*

------
https://chatgpt.com/codex/tasks/task_e_685c13d416d883268f0b208854ea8943