### PR TITLE
Fix padding for .room-list in layout.css

### DIFF
--- a/public/style/layout.css
+++ b/public/style/layout.css
@@ -144,7 +144,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
-  padding: 0 1rem 1rem 1rem;
+  padding: 0 0 1rem 0;
   overflow: auto;
   margin-top: 1rem;
 }


### PR DESCRIPTION
## Summary
- update `.room-list` padding so left and right values are zero

## Testing
- `npm test` *(fails: Cannot find module 'uuid')*

------
https://chatgpt.com/codex/tasks/task_e_685c1a5adb3c8326b96d1c2dc808a4e9