### PR TITLE
Adjust channel list CSS spacing

### DIFF
--- a/public/style/components/channel.css
+++ b/public/style/components/channel.css
@@ -1,6 +1,7 @@
 /* Channel Item */
 .channel-item {
-  width: 100%;
+  width: calc(100% - 16px);
+  margin-left: 16px;
   display: flex;
   flex-direction: column;
   justify-content: center;


### PR DESCRIPTION
## Summary
- tweak channel list CSS to use left margin so items don't overflow panel

## Testing
- `npm test` *(fails: Cannot find module 'uuid')*

------
https://chatgpt.com/codex/tasks/task_e_685c27f60d348326b045ec0c17902404