### PR TITLE
Adjust rooms panel styling

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -8,7 +8,8 @@
 
 .category-row {
   margin: 0.75rem 0;
-  padding-bottom: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
 }
 .category-header {
   display: flex;
@@ -43,11 +44,12 @@
   color: #575757;
 }
 .category-placeholder {
-  height: 30px;
-  margin-bottom: 4px;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px dashed #777;
-  border-radius: 4px;
+  width: 100%;
+  height: 1px;
+  background: #fff;
+  margin: 0;
+  border: none;
+  border-radius: 0;
 }
 
 .category-row.expanded .category-header {

--- a/public/style/components/channel.css
+++ b/public/style/components/channel.css
@@ -1,13 +1,13 @@
 /* Channel Item */
 .channel-item {
-  width: calc(100% - 16px);
-  margin-left: 16px;
+  width: calc(100% - 8px);
+  margin-left: 8px;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: flex-start;
   cursor: pointer;
-  padding: 5px 12px 5px 16px;
+  padding: 5px 12px 5px 8px;
   margin-bottom: 0;
   border-radius: 5px;
   background: #2d2d2d;
@@ -313,6 +313,7 @@
 .channel-item.unread:not(.muted) .channel-icon,
 .channel-item.unread:not(.muted) .channel-name {
   color: #eee;
+  font-weight: bold;
 }
 .channel-item.muted .channel-icon,
 .channel-item.muted .channel-name,
@@ -408,11 +409,12 @@
 
 /* Channel Reordering */
 .channel-placeholder {
-  height: 40px;
-  margin-bottom: 4px;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px dashed #777;
-  border-radius: 4px;
+  width: 100%;
+  height: 1px;
+  background: #fff;
+  margin: 0;
+  border: none;
+  border-radius: 0;
 }
 .channel-drag-preview {
   position: absolute;


### PR DESCRIPTION
## Summary
- make channel items narrower with 8px indentation
- bold channel name and icon when unread
- change drag placeholders to thin divider lines
- tweak category row vertical padding

## Testing
- `npm test` *(fails: test suite cannot run without dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685c2c3b91c08326b2adad8867d1f584