### PR TITLE
Fix auto-scroll when user near bottom

### DIFF
--- a/public/js/textChannel.js
+++ b/public/js/textChannel.js
@@ -358,6 +358,10 @@ function appendNewMessage(msg, container) {
   const sender = msg.username || "Anon";
   const fullTime = formatTimestamp(msg.timestamp);
   let newMsgClass = "last-message"; // varsayılan
+
+  const nearBottom =
+    container.scrollTop + container.clientHeight >=
+    container.scrollHeight - 20;
   
   // Son eklenen metin mesajı (date separator hariç) alınıyor.
   const messages = container.querySelectorAll('.text-message');
@@ -402,7 +406,9 @@ function appendNewMessage(msg, container) {
   });
   msgDiv.innerHTML = msgHTML;
   container.appendChild(msgDiv);
-  container.scrollTop = container.scrollHeight;
+  if (nearBottom) {
+    msgDiv.scrollIntoView({ behavior: 'smooth' });
+  }
   
   // Son mesaj bilgilerini güncelle (DOM üzerinden güncelleme yapılıyor)
   lastMessageInfo[container.dataset.channelId] = { sender, timestamp: new Date(msg.timestamp) };


### PR DESCRIPTION
## Summary
- tweak `appendNewMessage` to only auto-scroll when user is near the bottom of the chat

## Testing
- `npm test` *(fails: Cannot find module 'uuid', 'dotenv', 'bcryptjs', 'mongoose', 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_685c562abc188326be585a1aca15ff2a