### PR TITLE
Fix category reorder persistence

### DIFF
--- a/public/js/socketEvents.js
+++ b/public/js/socketEvents.js
@@ -283,7 +283,9 @@ export function initSocketEvents(socket) {
       if (!draggedCategoryEl || !categoryPlaceholder) return;
       e.preventDefault();
       categoryPlaceholder.parentNode.insertBefore(draggedCategoryEl, categoryPlaceholder);
-      const items = Array.from(roomListDiv.querySelectorAll('.category-row, .channel-item'));
+      const items = Array.from(roomListDiv.children).filter(el =>
+        el.classList.contains('category-row') || el.classList.contains('channel-item')
+      );
       const newIndex = items.indexOf(draggedCategoryEl);
       categoryPlaceholder.remove();
       categoryPlaceholder = null;


### PR DESCRIPTION
## Summary
- adjust index calculation when dropping categories to only count top-level items

## Testing
- `npm test` *(fails: test suite cannot run offline)*

------
https://chatgpt.com/codex/tasks/task_e_685d70fb80a88326bb0babb5838bb5d3