### PR TITLE
Fix category drag to bottom

### DIFF
--- a/public/js/socketEvents.js
+++ b/public/js/socketEvents.js
@@ -260,6 +260,11 @@ export function initSocketEvents(socket) {
     roomListDiv.addEventListener('dragover', (e) => {
       if (!draggedCategoryEl) return;
       e.preventDefault();
+      const contRect = roomListDiv.getBoundingClientRect();
+      if (e.clientY >= contRect.bottom - 5) {
+        roomListDiv.appendChild(categoryPlaceholder);
+        return;
+      }
       const targetEl = e.target.closest('.category-row, .channel-item');
       if (targetEl) {
         if (targetEl === draggedCategoryEl) return;
@@ -270,7 +275,6 @@ export function initSocketEvents(socket) {
           after ? targetEl.nextSibling : targetEl
         );
       } else {
-        const contRect = roomListDiv.getBoundingClientRect();
         const next = e.clientY - contRect.top > contRect.height / 2;
         roomListDiv.insertBefore(
           categoryPlaceholder,


### PR DESCRIPTION
## Summary
- allow category placeholder to attach to the very end of the rooms panel when dragging

## Testing
- `npm test` *(fails: npm requires network)*

------
https://chatgpt.com/codex/tasks/task_e_685d89d43d548326a7f7084ea201fb35