### PR TITLE
Add Vite React frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,14 @@ webpack.config.js   Bundles mediasoup-client into `public/libs`
    This invokes Webpack and generates both `public/libs/mediasoup-client.min.js`
    and `public/bundle.js`. The application will not start correctly without
    these files present.
-4. Start the application:
+4. Build the React front-end:
+    ```bash
+    npm run build:react
+    ```
+   This compiles the Vite project under `frontend/` and copies the resulting
+   `frontend/dist/app.js` bundle into the `public/` directory as
+   `public/app.js`.
+5. Start the application:
 ```bash
 npm start
 ```

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>React App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function App() {
+  return <div>Hello React</div>;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    cssCodeSplit: false,
+    rollupOptions: {
+      output: {
+        manualChunks: () => 'app',
+        entryFileNames: 'app.js',
+        chunkFileNames: 'app.js',
+      }
+    }
+  }
+});

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "node server.js",
     "test": "node --env-file=.env --test",
-    "build": "webpack"
+    "build": "webpack",
+    "build:react": "vite build --config frontend/vite.config.js && cp frontend/dist/app.js public/app.js"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",
@@ -27,7 +28,9 @@
     "uuid": "^11.0.3",
     "winston": "^3.17.0",
     "ws": "^8.18.0",
-    "jsonwebtoken": "^9.0.2"
+    "jsonwebtoken": "^9.0.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "keywords": [],
   "author": "",
@@ -35,6 +38,8 @@
   "description": "",
   "devDependencies": {
     "webpack": "^5.97.1",
-    "webpack-cli": "^6.0.1"
+    "webpack-cli": "^6.0.1",
+    "vite": "^5.0.10",
+    "@vitejs/plugin-react": "^4.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- scaffold React app under `frontend/`
- set up Vite config to emit a single bundle
- update npm scripts and dependencies
- document React build step

## Testing
- `npm test` *(fails: .env not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f31db6c888326b941b34c88747c8f