### PR TITLE
Refactor auth helpers for React forms

### DIFF
--- a/frontend/src/components/LoginForm.jsx
+++ b/frontend/src/components/LoginForm.jsx
@@ -9,19 +9,15 @@ export default function LoginForm({ onSwitch }) {
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    const userVal = username.trim();
-    const passVal = password.trim();
-    setError('');
     setShakeUser(false);
     setShakePass(false);
-    if (!userVal || !passVal) {
-      setError('Lütfen gerekli alanları doldurunuz');
+    const res = window.attemptLogin(window.socket, username, password);
+    if (!res.ok) {
+      setError(res.message || '');
       setShakeUser(true);
       setShakePass(true);
-      return;
-    }
-    if (window.socket) {
-      window.socket.emit('login', { username: userVal, password: passVal });
+    } else {
+      setError('');
     }
   };
 

--- a/frontend/src/components/RegisterForm.jsx
+++ b/frontend/src/components/RegisterForm.jsx
@@ -15,51 +15,28 @@ export default function RegisterForm({ onSwitch }) {
   const [shakePassConf, setShakePassConf] = useState(false);
 
   const handleRegister = () => {
-    const u = username.trim();
-    const n = name.trim();
-    const s = surname.trim();
-    const b = birthdate.trim();
-    const e = email.trim();
-    const p = phone.trim();
-    const pw = password.trim();
-    const pwc = passwordConfirm.trim();
-    setError('');
     setShakeUser(false);
     setShakePass(false);
     setShakePassConf(false);
-
-    if (!u || !n || !s || !b || !e || !p || !pw || !pwc) {
-      setError('Lütfen tüm alanları doldurunuz.');
-      return;
-    }
-    if (u !== u.toLowerCase()) {
-      setError('Kullanıcı adı sadece küçük harf olmalı!');
-      setShakeUser(true);
-      return;
-    }
-    if (pw !== pwc) {
-      setError('Parolalar eşleşmiyor!');
-      setShakePass(true);
-      setShakePassConf(true);
-      return;
-    }
-    const complexityRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[\W_]).{8,}$/;
-    if (!complexityRegex.test(pw)) {
-      setError('Parola en az 8 karakter, büyük/küçük harf, rakam ve özel karakter içermeli.');
-      setShakePass(true);
-      return;
-    }
-    if (window.socket) {
-      window.socket.emit('register', {
-        username: u,
-        name: n,
-        surname: s,
-        birthdate: b,
-        email: e,
-        phone: p,
-        password: pw,
-        passwordConfirm: pwc,
-      });
+    const res = window.attemptRegister(window.socket, {
+      username,
+      name,
+      surname,
+      birthdate,
+      email,
+      phone,
+      password,
+      passwordConfirm,
+    });
+    if (!res.ok) {
+      setError(res.message || '');
+      if (res.message && res.message.includes('Kullanıcı adı')) setShakeUser(true);
+      if (res.message && res.message.includes('Parola')) {
+        setShakePass(true);
+        if (res.message.includes('eşleşmiyor')) setShakePassConf(true);
+      }
+    } else {
+      setError('');
     }
   };
 

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -1,59 +1,32 @@
 import logger from '../utils/logger.js';
 
-export function attemptRegister(socket, elements) {
-  const {
-    regUsernameInput,
-    regNameInput,
-    regSurnameInput,
-    regBirthdateInput,
-    regEmailInput,
-    regPhoneInput,
-    regPasswordInput,
-    regPasswordConfirmInput,
-    registerErrorMessage
-  } = elements;
+export function attemptRegister(socket, fields) {
+  const usernameVal = (fields.username || '').trim();
+  const nameVal     = (fields.name || '').trim();
+  const surnameVal  = (fields.surname || '').trim();
+  const birthVal    = (fields.birthdate || '').trim();
+  const emailVal    = (fields.email || '').trim();
+  const phoneVal    = (fields.phone || '').trim();
+  const passVal     = (fields.password || '').trim();
+  const passConfVal = (fields.passwordConfirm || '').trim();
 
   logger.info('🔐 attemptRegister tetiklendi');
 
-  const usernameVal = regUsernameInput.value.trim();
-  const nameVal     = regNameInput.value.trim();
-  const surnameVal  = regSurnameInput.value.trim();
-  const birthVal    = regBirthdateInput.value.trim();
-  const emailVal    = regEmailInput.value.trim();
-  const phoneVal    = regPhoneInput.value.trim();
-  const passVal     = regPasswordInput.value.trim();
-  const passConfVal = regPasswordConfirmInput.value.trim();
-
-  registerErrorMessage.style.display = 'none';
-  [regUsernameInput, regPasswordInput, regPasswordConfirmInput].forEach(el => el.classList.remove('shake'));
-
   if (!usernameVal || !nameVal || !surnameVal || !birthVal || !emailVal || !phoneVal || !passVal || !passConfVal) {
-    registerErrorMessage.textContent = 'Lütfen tüm alanları doldurunuz.';
-    registerErrorMessage.style.display = 'block';
-    return;
+    return { ok: false, message: 'Lütfen tüm alanları doldurunuz.' };
   }
 
   if (usernameVal !== usernameVal.toLowerCase()) {
-    registerErrorMessage.textContent = 'Kullanıcı adı sadece küçük harf olmalı!';
-    registerErrorMessage.style.display = 'block';
-    regUsernameInput.classList.add('shake');
-    return;
+    return { ok: false, message: 'Kullanıcı adı sadece küçük harf olmalı!' };
   }
 
   if (passVal !== passConfVal) {
-    registerErrorMessage.textContent = 'Parolalar eşleşmiyor!';
-    registerErrorMessage.style.display = 'block';
-    regPasswordInput.classList.add('shake');
-    regPasswordConfirmInput.classList.add('shake');
-    return;
+    return { ok: false, message: 'Parolalar eşleşmiyor!' };
   }
 
   const complexityRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[\W_]).{8,}$/;
   if (!complexityRegex.test(passVal)) {
-    registerErrorMessage.textContent = 'Parola en az 8 karakter, büyük/küçük harf, rakam ve özel karakter içermeli.';
-    registerErrorMessage.style.display = 'block';
-    regPasswordInput.classList.add('shake');
-    return;
+    return { ok: false, message: 'Parola en az 8 karakter, büyük/küçük harf, rakam ve özel karakter içermeli.' };
   }
 
   socket.emit('register', {
@@ -66,20 +39,18 @@ export function attemptRegister(socket, elements) {
     password: passVal,
     passwordConfirm: passConfVal
   });
+
+  return { ok: true };
 }
 
-export function attemptLogin(socket, usernameInput, passwordInput, errorElem) {
-  const usernameVal = usernameInput.value.trim();
-  const passwordVal = passwordInput.value.trim();
-  errorElem.style.display = 'none';
-  usernameInput.classList.remove('shake');
-  passwordInput.classList.remove('shake');
+export function attemptLogin(socket, username, password) {
+  const usernameVal = (username || '').trim();
+  const passwordVal = (password || '').trim();
+
   if (!usernameVal || !passwordVal) {
-    errorElem.textContent = 'Lütfen gerekli alanları doldurunuz';
-    errorElem.style.display = 'block';
-    usernameInput.classList.add('shake');
-    passwordInput.classList.add('shake');
-    return;
+    return { ok: false, message: 'Lütfen gerekli alanları doldurunuz' };
   }
+
   socket.emit('login', { username: usernameVal, password: passwordVal });
+  return { ok: true };
 }

--- a/public/script.js
+++ b/public/script.js
@@ -68,6 +68,7 @@ import { applyAudioStates } from "./js/audioUtils.js";
 import { initUserSettings, openUserSettings, closeUserSettings } from "./js/userSettings.js";
 import { showProfilePopout, initProfilePopout } from "./js/profilePopout.js";
 import { initAttachments } from "./js/attachments.js";
+import { attemptLogin, attemptRegister } from "./js/auth.js";
 
 let socket = null;
 let device = null;   // mediasoup-client Device
@@ -372,7 +373,9 @@ Object.assign(window, {
   categoryModal,
   modalCategoryName,
   modalCreateCategoryBtn,
-  modalCloseCategoryBtn
+  modalCloseCategoryBtn,
+  attemptLogin,
+  attemptRegister
 });
 window.WebRTC = WebRTC;
 window.joinRoom = WebRTC.joinRoom;


### PR DESCRIPTION
## Summary
- refactor `attemptLogin` and `attemptRegister` to validate plain values and return status objects
- expose auth helpers globally in `script.js`
- use the new helpers from the React login and register forms

## Testing
- `npm test` *(fails: `.env` not found and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_685f3597e42083269512cf04808afc07