### PR TITLE
Add React form tests

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "frontend",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@testing-library/react": "^14.1.2",
+    "@vitejs/plugin-react": "^4.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/frontend/test/loginForm.test.jsx
+++ b/frontend/test/loginForm.test.jsx
@@ -1,0 +1,25 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import LoginForm from '../src/components/LoginForm.jsx';
+import { attemptLogin } from '../../public/js/auth.js';
+
+vi.stubGlobal('socket', { emit: vi.fn() });
+vi.stubGlobal('attemptLogin', attemptLogin);
+
+beforeEach(() => {
+  socket.emit.mockClear();
+});
+
+describe('LoginForm', () => {
+  it('emits login event with entered credentials', () => {
+    render(<LoginForm onSwitch={() => {}} />);
+    fireEvent.change(screen.getByPlaceholderText('Kullanıcı Adı'), {
+      target: { value: 'alice' }
+    });
+    fireEvent.change(screen.getByPlaceholderText('Parola'), {
+      target: { value: 'Secret1!' }
+    });
+    fireEvent.click(screen.getByText('Giriş Yap'));
+    expect(socket.emit).toHaveBeenCalledWith('login', { username: 'alice', password: 'Secret1!' });
+  });
+});

--- a/frontend/test/registerForm.test.jsx
+++ b/frontend/test/registerForm.test.jsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import RegisterForm from '../src/components/RegisterForm.jsx';
+import { attemptRegister } from '../../public/js/auth.js';
+
+vi.stubGlobal('socket', { emit: vi.fn() });
+vi.stubGlobal('attemptRegister', attemptRegister);
+
+beforeEach(() => {
+  socket.emit.mockClear();
+});
+
+describe('RegisterForm', () => {
+  it('emits register event with provided info', () => {
+    render(<RegisterForm onSwitch={() => {}} />);
+    fireEvent.change(screen.getByPlaceholderText('Kullanıcı Adı (küçük harf)'), {
+      target: { value: 'bob' }
+    });
+    fireEvent.change(screen.getByPlaceholderText('İsim'), { target: { value: 'Bob' } });
+    fireEvent.change(screen.getByPlaceholderText('Soyisim'), { target: { value: 'Builder' } });
+    fireEvent.change(document.getElementById('regBirthdateInput'), {
+      target: { value: '2000-01-01' }
+    });
+    fireEvent.change(screen.getByPlaceholderText('E-Posta'), { target: { value: 'b@example.com' } });
+    fireEvent.change(screen.getByPlaceholderText('Telefon Numarası'), { target: { value: '555' } });
+    fireEvent.change(screen.getByPlaceholderText('Parola'), { target: { value: 'Secret1!' } });
+    fireEvent.change(screen.getByPlaceholderText('Parola(Tekrar)'), { target: { value: 'Secret1!' } });
+    fireEvent.click(screen.getByText('Kayıt Ol ve Başla'));
+    expect(socket.emit).toHaveBeenCalledWith('register', {
+      username: 'bob',
+      name: 'Bob',
+      surname: 'Builder',
+      birthdate: '2000-01-01',
+      email: 'b@example.com',
+      phone: '555',
+      password: 'Secret1!',
+      passwordConfirm: 'Secret1!'
+    });
+  });
+});

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom'
+  }
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node --env-file=.env --test",
+    "test": "node --env-file=.env --test && npm run test:react",
+    "test:react": "vitest run --config frontend/vitest.config.js",
     "build": "webpack",
     "build:react": "vite build --config frontend/vite.config.js && cp frontend/dist/app.js public/app.js"
   },


### PR DESCRIPTION
## Summary
- add test:react script to run React unit tests using vitest
- add vitest config with jsdom and React plugin
- add React Testing Library unit tests covering LoginForm and RegisterForm
- add a minimal frontend package.json for the test tooling

## Testing
- `npm test` *(fails: Cannot find module 'uuid')*
- `npm run test:react` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f376fb6308326b9a1bca76e404350