### PR TITLE
Verify client build files before starting server

### DIFF
--- a/server.js
+++ b/server.js
@@ -108,6 +108,18 @@ async function startServer() {
     logger.info(`Startup: groups=${grpCount}, categories=${catCount}, channels=${channelsLoaded}`);
     logger.info("Uygulama başlangıç yüklemeleri tamam.");
 
+    const requiredFiles = [
+      path.join(__dirname, 'public', 'app.js'),
+      path.join(__dirname, 'public', 'bundle.js'),
+      path.join(__dirname, 'public', 'libs', 'mediasoup-client.min.js')
+    ];
+    const missing = requiredFiles.filter(f => !fs.existsSync(f));
+    if (missing.length) {
+      const names = missing.map(f => path.relative(__dirname, f)).join(', ');
+      logger.error(`Missing build files: ${names}. Run \"npm run build\" or \"npm run build:react\".`);
+      process.exit(1);
+    }
+
     server.listen(PORT, () => {
       logger.info(`Sunucu çalışıyor: http://localhost:${PORT}`);
     });


### PR DESCRIPTION
## Summary
- ensure `public/app.js`, `public/bundle.js`, and mediasoup client exist
- log an error and exit if they are missing

## Testing
- `bash setup.sh` *(fails: Forbidden to access npm registry)*
- `npm test` *(fails: .env not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f3b51d618832680d151af2dab3312