### PR TITLE
fix: set Vite root to frontend directory

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,7 +1,12 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
+  root: __dirname,
   plugins: [react()],
   build: {
     outDir: 'dist',


### PR DESCRIPTION
## Summary
- use `__dirname` in Vite configuration
- set Vite `root` to the frontend folder

## Testing
- `npm run build:react` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f3dc0930883269b2ee7a603a38ac4