### PR TITLE
Fix react test setup in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
           cache: 'npm'
       - name: Install dependencies
         run: bash ./setup.sh
+      - name: Install frontend dependencies
+        run: npm --prefix frontend install --no-audit --no-fund
       - name: Build client bundle
         run: npm run build
       - name: Run tests

--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ webpack.config.js   Bundles mediasoup-client into `public/libs`
    ./setup.sh
    ```
    This script runs `npm ci` to fetch Node packages and is
-   also executed in CI before running the tests.
+   also executed in CI before running the tests. The React
+   test dependencies are installed automatically during
+   `npm test` so no extra setup is required.
 2. Copy `.env.example` to `.env` and update the values.
 3. Build the bundled client files by running:
     ```bash
@@ -89,7 +91,7 @@ Install the dependencies and execute the test suite with:
 
 ```bash
 ./setup.sh     # installs required Node packages
-npm test
+npm test       # installs frontend test deps and runs all tests
 ```
 
 ## Login flow

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "node server.js",
     "test": "node --env-file=.env --test && npm run test:react",
-    "test:react": "vitest run --config frontend/vitest.config.js",
+    "test:react": "npm --prefix frontend install --no-audit --no-fund && vitest run --config frontend/vitest.config.js",
     "build": "webpack && npm run build:react",
     "build:react": "vite build --config frontend/vite.config.js && copy frontend\\dist\\app.js public\\app.js"
   },


### PR DESCRIPTION
## Summary
- ensure the CI installs frontend dev packages
- auto-install frontend deps when running vitest
- clarify setup and testing steps in README

## Testing
- `npm test` *(fails: `.env` file missing)*

------
https://chatgpt.com/codex/tasks/task_e_685f4e3c76a48326917f20d067530c01