### PR TITLE
Fix cross platform copy command

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ webpack.config.js   Bundles mediasoup-client into `public/libs`
     ```
    This compiles the Vite project under `frontend/` and copies the resulting
    `frontend/dist/app.js` bundle into the `public/` directory as
-   `public/app.js`.
+   `public/app.js` using a cross-platform `cp` command.
 5. Start the application:
 ```bash
 npm start

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "node --env-file=.env --test && npm run test:react",
     "test:react": "npm --prefix frontend install --no-audit --no-fund && vitest run --config frontend/vitest.config.js",
     "build": "webpack && npm run build:react",
-    "build:react": "vite build --config frontend/vite.config.js && copy frontend\\dist\\app.js public\\app.js"
+    "build:react": "vite build --config frontend/vite.config.js && cp frontend/dist/app.js public/app.js"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",


### PR DESCRIPTION
## Summary
- use `cp` instead of Windows `copy` command
- mention cross-platform copy in README

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_e_685f504ecf608326ac030e7ca5e22af4