### PR TITLE
Add react dev deps for frontend

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,8 @@
   "devDependencies": {
     "@testing-library/react": "^14.1.2",
     "@vitejs/plugin-react": "^4.0.0",
-    "vitest": "^1.0.0"
+    "vitest": "^1.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   }
 }


### PR DESCRIPTION
## Summary
- add `react` and `react-dom` as dev dependencies for the frontend

## Testing
- `npm install --prefix frontend` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685f53b8af348326a97cf0dab437e200