### PR TITLE
Remove legacy callScreen container

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -429,6 +429,11 @@ window.applyAudioStates = (opts) => {
 };
 window.addEventListener('DOMContentLoaded', () => {
   toggleDMButton.querySelector('.material-icons').textContent = 'forum';
+
+  // Ensure screen references are captured now that React has rendered
+  if (window.initScreenRefs) {
+    window.initScreenRefs();
+  }
   
   // Hide voice channel sections until a voice channel is joined
   hideVoiceSections();


### PR DESCRIPTION
## Summary
- ensure scripts read the React-rendered DOM

## Testing
- `npm test` *(fails: `.env` not found and network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685f54aaa21c8326945a6c7928301204