### PR TITLE
Expose auth functions pre-DOM load

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -70,6 +70,10 @@ import { showProfilePopout, initProfilePopout } from "./js/profilePopout.js";
 import { initAttachments } from "./js/attachments.js";
 import { attemptLogin, attemptRegister } from "./js/auth.js";
 
+// Expose auth helpers early so they are available even before DOMContentLoaded
+window.attemptLogin = attemptLogin;
+window.attemptRegister = attemptRegister;
+
 let socket = null;
 let device = null;   // mediasoup-client Device
 


### PR DESCRIPTION
## Summary
- ensure login helpers are available before DOMContentLoaded so login still works even if DOM lookups fail

## Testing
- `npm test` *(fails: `.env` not found and network is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_685f5ebf3a648326b6754598816f00e9