### PR TITLE
Swap script order in index.html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -205,8 +205,8 @@
     <script src="https://cdn.socket.io/4.8.1/socket.io.min.js"></script>
     <script src="libs/mediasoup-client.min.js"></script>
     <script src="https://unpkg.com/cropperjs@1.5.13/dist/cropper.min.js"></script>
-    <script type="module" src="app.js"></script>
     <!-- Uygulama JavaScript'i webpack ile derlenmiş bundle.js'de -->
     <script src="bundle.js"></script>
+    <script type="module" src="app.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- load bundle.js before app.js so global functions are available earlier

## Testing
- `npm test` *(fails: npm cannot download packages in the test step)*

------
https://chatgpt.com/codex/tasks/task_e_685fcf4dc09083269dc12f6c404a4250