### PR TITLE
Use logger for error reporting

### DIFF
--- a/controllers/groupController.js
+++ b/controllers/groupController.js
@@ -102,7 +102,7 @@ async function loadGroupsFromDB({ Group, groups }) {
       logger.info('loadGroupsFromDB tamam, groups:', groupKeys);
     }
   } catch (err) {
-    console.error('loadGroupsFromDB hata:', err);
+    logger.error('loadGroupsFromDB hata:', err);
   }
 }
 
@@ -191,7 +191,7 @@ async function sendGroupsListToUser(io, socketId, { User, users, GroupMember }) 
     );
     io.to(socketId).emit('groupsList', groupList);
   } catch (err) {
-    console.error('sendGroupsListToUser hatası:', err);
+    logger.error('sendGroupsListToUser hatası:', err);
   }
 }
 
@@ -265,7 +265,7 @@ async function sendRoomsListToUser(io, socketId, context, groupId) {
         }
       }
     } catch (err) {
-      console.error('sendRoomsListToUser error:', err);
+      logger.error('sendRoomsListToUser error:', err);
     }
   }
   const groupObj = groups[groupId];
@@ -466,7 +466,7 @@ async function broadcastGroupUsers(io, groups, onlineUsernames, Group, groupId) 
     });
     io.to(groupId).emit('groupUsers', { online, offline });
   } catch (err) {
-    console.error('broadcastGroupUsers hata:', err);
+    logger.error('broadcastGroupUsers hata:', err);
   }
 }
 
@@ -518,7 +518,7 @@ async function handleLeaveGroup(io, socket, context, groupId) {
       await groupDoc.save();
     }
   } catch (err) {
-    console.error('leaveGroup error:', err);
+    logger.error('leaveGroup error:', err);
   }
 
   await sendGroupsListToUser(io, socket.id, { User, users, GroupMember });
@@ -587,7 +587,7 @@ function register(io, socket, context) {
       });
       broadcastGroupUsers(io, groups, onlineUsernames, Group, groupId);
     } catch (err) {
-      console.error('Create group error:', err);
+      logger.error('Create group error:', err);
       socket.emit('errorMessage', 'Grup oluşturulurken bir hata oluştu.');
     }
   });
@@ -644,7 +644,7 @@ function register(io, socket, context) {
       broadcastAllChannelsData(io, users, groups, groupId);
       broadcastGroupUsers(io, groups, onlineUsernames, Group, groupId);
     } catch (err) {
-      console.error('joinGroup error:', err);
+      logger.error('joinGroup error:', err);
     }
   });
 
@@ -698,7 +698,7 @@ function register(io, socket, context) {
       broadcastAllChannelsData(io, users, groups, groupId);
       broadcastGroupUsers(io, groups, onlineUsernames, Group, groupId);
     } catch (err) {
-      console.error('joinRoom error:', err);
+      logger.error('joinRoom error:', err);
     }
   });
 
@@ -741,7 +741,7 @@ function register(io, socket, context) {
       broadcastAllChannelsData(io, users, groups, groupId);
       broadcastGroupUsers(io, groups, onlineUsernames, Group, groupId);
     } catch (err) {
-      console.error('moveUser error:', err);
+      logger.error('moveUser error:', err);
     }
   });
   
@@ -778,7 +778,7 @@ function register(io, socket, context) {
         broadcastRoomsListToGroup(io, groups, groupId);
       }
     } catch (err) {
-      console.error('createChannel error:', err);
+      logger.error('createChannel error:', err);
     }
   });
 
@@ -800,7 +800,7 @@ function register(io, socket, context) {
         broadcastRoomsListToGroup(io, groups, gid);
       }
     } catch (err) {
-      console.error('renameChannel error:', err);
+      logger.error('renameChannel error:', err);
     }
   });
 
@@ -837,7 +837,7 @@ function register(io, socket, context) {
       broadcastRoomsListToGroup(io, groups, groupId);
       broadcastAllChannelsData(io, users, groups, groupId);
     } catch (err) {
-      console.error('reorderChannel error:', err);
+      logger.error('reorderChannel error:', err);
     }
   });
   
@@ -875,7 +875,7 @@ function register(io, socket, context) {
         broadcastRoomsListToGroup(io, groups, gid);
       }
     } catch (err) {
-      console.error('deleteChannel error:', err);
+      logger.error('deleteChannel error:', err);
     }
   });
 
@@ -893,7 +893,7 @@ function register(io, socket, context) {
       if (context.store) context.store.setJSON(context.store.key('group', groupId), groups[groupId]);
       broadcastRoomsListToGroup(io, groups, groupId);
     } catch (err) {
-      console.error('createCategory error:', err);
+      logger.error('createCategory error:', err);
     }
   });
 
@@ -912,7 +912,7 @@ function register(io, socket, context) {
         broadcastRoomsListToGroup(io, groups, gid);
       }
     } catch (err) {
-      console.error('renameCategory error:', err);
+      logger.error('renameCategory error:', err);
     }
   });
 
@@ -935,7 +935,7 @@ function register(io, socket, context) {
         broadcastRoomsListToGroup(io, groups, gid);
       }
     } catch (err) {
-      console.error('deleteCategory error:', err);
+      logger.error('deleteCategory error:', err);
     }
   });
 
@@ -987,7 +987,7 @@ function register(io, socket, context) {
       if (context.store) context.store.setJSON(context.store.key('group', groupId), grp);
       broadcastRoomsListToGroup(io, groups, groupId);
     } catch (err) {
-      console.error('reorderCategory error:', err);
+      logger.error('reorderCategory error:', err);
     }
   });
 
@@ -1010,7 +1010,7 @@ function register(io, socket, context) {
       if (context.store) context.store.setJSON(context.store.key('group', groupId), grp);
       broadcastRoomsListToGroup(io, groups, groupId);
     } catch (err) {
-      console.error('assignChannelCategory error:', err);
+      logger.error('assignChannelCategory error:', err);
     }
   });
 
@@ -1036,7 +1036,7 @@ function register(io, socket, context) {
         }
       });
     } catch (err) {
-      console.error('setCategoryCollapsed error:', err);
+      logger.error('setCategoryCollapsed error:', err);
     }
   });
   
@@ -1057,7 +1057,7 @@ function register(io, socket, context) {
       );
       io.to(socket.id).emit('groupUnreadReset', { groupId });
     } catch (err) {
-      console.error('markGroupRead error:', err);
+      logger.error('markGroupRead error:', err);
     }
   });
 
@@ -1096,7 +1096,7 @@ function register(io, socket, context) {
         }
       });
     } catch (err) {
-      console.error('muteGroup error:', err);
+      logger.error('muteGroup error:', err);
     }
   });
 
@@ -1135,7 +1135,7 @@ function register(io, socket, context) {
         }
       });
     } catch (err) {
-      console.error('muteChannel error:', err);
+      logger.error('muteChannel error:', err);
     }
   });
 
@@ -1172,7 +1172,7 @@ function register(io, socket, context) {
         }
       });
     } catch (err) {
-      console.error('muteCategory error:', err);
+      logger.error('muteCategory error:', err);
     }
   });
 
@@ -1197,7 +1197,7 @@ function register(io, socket, context) {
         }
       });
     } catch (err) {
-      console.error('setGroupNotifyType error:', err);
+      logger.error('setGroupNotifyType error:', err);
     }
   });
 
@@ -1224,7 +1224,7 @@ function register(io, socket, context) {
         }
       });
     } catch (err) {
-      console.error('setChannelNotifyType error:', err);
+      logger.error('setChannelNotifyType error:', err);
     }
   });
   // Diğer handlerlar (joinGroupByID, browseGroup, createRoom, joinRoom, leaveRoom,

--- a/utils/collectCategoryPrefs.js
+++ b/utils/collectCategoryPrefs.js
@@ -1,3 +1,4 @@
+const logger = require('./logger');
 const getEntries = map => {
   if (!map) return [];
   if (typeof map.entries === 'function') return Array.from(map.entries());
@@ -32,7 +33,7 @@ async function collectCategoryPrefs(username, { User, Group, GroupMember }) {
       };
     }));
   } catch (err) {
-    console.error('collectCategoryPrefs error:', err);
+    logger.error('collectCategoryPrefs error:', err);
   }
   return result;
 }

--- a/utils/collectMentionCounts.js
+++ b/utils/collectMentionCounts.js
@@ -1,3 +1,4 @@
+const logger = require('./logger');
 const getEntries = map => {
   if (!map) return [];
   if (typeof map.entries === 'function') return Array.from(map.entries());
@@ -22,7 +23,7 @@ async function collectMentionCounts(username, { User, Group, GroupMember }) {
       }
     }));
   } catch (err) {
-    console.error('collectMentionCounts error:', err);
+    logger.error('collectMentionCounts error:', err);
   }
   return result;
 }

--- a/utils/collectMuteInfo.js
+++ b/utils/collectMuteInfo.js
@@ -1,3 +1,4 @@
+const logger = require('./logger');
 const getEntries = map => {
   if (!map) return [];
   if (typeof map.entries === 'function') return Array.from(map.entries());
@@ -39,7 +40,7 @@ async function collectMuteInfo(username, { User, Group, GroupMember }) {
       }
     }));
   } catch (err) {
-    console.error('collectMuteInfo error:', err);
+    logger.error('collectMuteInfo error:', err);
   }
   return result;
 }

--- a/utils/collectNotifyInfo.js
+++ b/utils/collectNotifyInfo.js
@@ -1,3 +1,4 @@
+const logger = require('./logger');
 const getEntries = map => {
   if (!map) return [];
   if (typeof map.entries === 'function') return Array.from(map.entries());
@@ -30,7 +31,7 @@ async function collectNotifyInfo(username, { User, Group, GroupMember }) {
       };
     }));
   } catch (err) {
-    console.error('collectNotifyInfo error:', err);
+    logger.error('collectNotifyInfo error:', err);
   }
   return result;
 }

--- a/utils/collectUnreadCounts.js
+++ b/utils/collectUnreadCounts.js
@@ -1,3 +1,4 @@
+const logger = require('./logger');
 const getEntries = map => {
   if (!map) return [];
   if (typeof map.entries === 'function') return Array.from(map.entries());
@@ -22,7 +23,7 @@ async function collectUnreadCounts(username, { User, Group, GroupMember }) {
       }
     }));
   } catch (err) {
-    console.error('collectUnreadCounts error:', err);
+    logger.error('collectUnreadCounts error:', err);
   }
   return result;
 }

--- a/utils/emitChannelUnread.js
+++ b/utils/emitChannelUnread.js
@@ -1,3 +1,4 @@
+const logger = require('./logger');
 async function emitChannelUnread(io, groupId, channelId, Group, Channel, userSessions, GroupMember, users, mentions = []) {
   try {
     let groupDoc = await Group.findOne({ groupId });
@@ -77,7 +78,7 @@ async function emitChannelUnread(io, groupId, channelId, Group, Channel, userSes
     }
     if (updates.length) await Promise.all(updates);
   } catch (err) {
-    console.error('emitChannelUnread error:', err);
+    logger.error('emitChannelUnread error:', err);
   }
 }
 

--- a/utils/emitMentionUnread.js
+++ b/utils/emitMentionUnread.js
@@ -1,3 +1,4 @@
+const logger = require('./logger');
 async function emitMentionUnread(io, groupId, channelId, username, Group, userSessions, GroupMember, users) {
   try {
     let groupDoc = await Group.findOne({ groupId });
@@ -42,7 +43,7 @@ async function emitMentionUnread(io, groupId, channelId, username, Group, userSe
       io.to(sid).emit('mentionUnread', { groupId, channelId });
     }
   } catch (err) {
-    console.error('emitMentionUnread error:', err);
+    logger.error('emitMentionUnread error:', err);
   }
 }
 


### PR DESCRIPTION
## Summary
- switch error outputs in controllers and utilities to use `logger`

## Testing
- `npm test` *(fails: test suite returns 37 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_685fd1abc7248326b2d42c9b9775f0af