### PR TITLE
Add catch-all 404 handler

### DIFF
--- a/server.js
+++ b/server.js
@@ -486,6 +486,9 @@ io.on("connection", async (socket) => {
   socket.on("disconnect", () => { groupController.handleDisconnect(io, socket, context); });
 });
 
+// 404 handler for unknown routes
+app.use((req, res) => res.status(404).json({ error: 'not found' }));
+
 // Express hata middleware'i (route'lardan sonra olacak!)
 app.use(expressWinston.errorLogger({
   winstonInstance: logger

--- a/test/unknownRoute404.test.js
+++ b/test/unknownRoute404.test.js
@@ -1,0 +1,28 @@
+const test = require('node:test');
+const assert = require('assert');
+
+function loadServer() {
+  const originalSetInterval = global.setInterval;
+  global.setInterval = () => ({ unref() {} });
+
+  delete require.cache[require.resolve('../server')];
+  const serverModule = require('../server');
+
+  global.setInterval = originalSetInterval;
+  return serverModule;
+}
+
+test('unknown route returns 404 json', async () => {
+  process.env.NODE_ENV = 'test';
+  const { app } = loadServer();
+  const srv = app.listen(0);
+  const port = srv.address().port;
+
+  const res = await fetch(`http://localhost:${port}/does-not-exist`);
+  const body = await res.json();
+
+  assert.strictEqual(res.status, 404);
+  assert.deepStrictEqual(body, { error: 'not found' });
+
+  srv.close();
+});


### PR DESCRIPTION
## Summary
- return a JSON 404 for unknown routes
- test that unknown routes send the 404 response

## Testing
- `npm test` *(fails: Cannot find module 'bcryptjs')*

------
https://chatgpt.com/codex/tasks/task_e_685fd33784308326aa0f102ec5641b5d