### PR TITLE
Fix watchers field alignment

### DIFF
--- a/server.js
+++ b/server.js
@@ -443,7 +443,7 @@ io.on("connection", async (socket) => {
     screenShareProducerId: null,
     hasMic: true,
     watching: [],
-  watchers: []
+    watchers: [],
   });
 
   if (socket.user && socket.user.username) {


### PR DESCRIPTION
## Summary
- align the `watchers` property in `server.js`
- add a trailing comma after `watchers`

## Testing
- `npm test` *(fails: `.env` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fd4ffbb0c8326a6369e9f2c770d48