### PR TITLE
Fix React build script for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ webpack.config.js   Bundles mediasoup-client into `public/libs`
     ```
    This compiles the Vite project under `frontend/` and copies the resulting
    `frontend/dist/app.js` bundle into the `public/` directory as
-   `public/app.js` using a cross-platform `cp` command.
+   `public/app.js` using a Node-based copy command.
 5. Start the application:
 ```bash
 npm start

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "node --env-file=.env --test && npm run test:react",
     "test:react": "npm --prefix frontend install --no-audit --no-fund && vitest run --config frontend/vitest.config.js",
     "build": "webpack && npm run build:react",
-    "build:react": "vite build --config frontend/vite.config.js && cp frontend/dist/app.js public/app.js"
+    "build:react": "vite build --config frontend/vite.config.js && node -e \"require('fs').copyFileSync('frontend/dist/app.js','public/app.js')\""
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",


### PR DESCRIPTION
## Summary
- make `npm run build:react` use a Node copy command for cross-platform builds
- update README to mention Node-based copy step

## Testing
- `npm test` *(fails: `.env` not found and no network access)*

------
https://chatgpt.com/codex/tasks/task_e_685fd7df5dd88326aaaab035114d60d2