### PR TITLE
Add SocketProvider and update auth forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ webpack.config.js   Bundles mediasoup-client into `public/libs`
    ./setup.sh
    ```
    This script runs `npm ci` and `npm --prefix frontend ci` to fetch
-   backend and frontend Node packages. It is also executed in CI before
+   backend and frontend Node packages, including the `socket.io-client`
+   dependency used by the React Socket provider. It is also executed in CI before
    running the tests.
 2. Copy `.env.example` to `.env` and update the values.
 3. Build the bundled client files by running:
@@ -69,11 +70,14 @@ webpack.config.js   Bundles mediasoup-client into `public/libs`
    after cloning the repository so they are recreated.
 4. Build the React front-end:
     ```bash
-    npm run build:react
-    ```
+   npm run build:react
+   ```
    This compiles the Vite project under `frontend/` and copies the resulting
    `frontend/dist/app.js` bundle into the `public/` directory as
    `public/app.js` using a Node-based copy command.
+   The React application uses a `SocketProvider` component which creates the
+   Socket.IO client with `socket.io-client` and assigns it to `window.socket` so
+   the scripts under `public/` can reuse the same connection.
 5. Start the application:
 ```bash
 npm start

--- a/frontend/src/SocketProvider.jsx
+++ b/frontend/src/SocketProvider.jsx
@@ -1,0 +1,21 @@
+import React, { createContext, useState } from 'react';
+import { io } from 'socket.io-client';
+
+export const SocketContext = createContext(null);
+
+export function SocketProvider({ children }) {
+  const [socket] = useState(() => {
+    if (typeof window === 'undefined') return null;
+    if (window.socket) return window.socket;
+    const socketURL = window.SOCKET_URL || window.location.origin;
+    const s = io(socketURL, { transports: ['websocket'] });
+    window.socket = s;
+    return s;
+  });
+
+  return (
+    <SocketContext.Provider value={socket}>
+      {children}
+    </SocketContext.Provider>
+  );
+}

--- a/frontend/src/components/LoginForm.jsx
+++ b/frontend/src/components/LoginForm.jsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
+import { SocketContext } from '../SocketProvider.jsx';
 
 export default function LoginForm({ onSwitch }) {
   const [username, setUsername] = useState('');
@@ -6,12 +7,13 @@ export default function LoginForm({ onSwitch }) {
   const [error, setError] = useState('');
   const [shakeUser, setShakeUser] = useState(false);
   const [shakePass, setShakePass] = useState(false);
+  const socket = useContext(SocketContext);
 
   const handleSubmit = (e) => {
     e.preventDefault();
     setShakeUser(false);
     setShakePass(false);
-    const res = window.attemptLogin(window.socket, username, password);
+    const res = window.attemptLogin(socket, username, password);
     if (!res.ok) {
       setError(res.message || '');
       setShakeUser(true);

--- a/frontend/src/components/RegisterForm.jsx
+++ b/frontend/src/components/RegisterForm.jsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
+import { SocketContext } from '../SocketProvider.jsx';
 
 export default function RegisterForm({ onSwitch }) {
   const [username, setUsername] = useState('');
@@ -13,12 +14,13 @@ export default function RegisterForm({ onSwitch }) {
   const [shakeUser, setShakeUser] = useState(false);
   const [shakePass, setShakePass] = useState(false);
   const [shakePassConf, setShakePassConf] = useState(false);
+  const socket = useContext(SocketContext);
 
   const handleRegister = () => {
     setShakeUser(false);
     setShakePass(false);
     setShakePassConf(false);
-    const res = window.attemptRegister(window.socket, {
+    const res = window.attemptRegister(socket, {
       username,
       name,
       surname,

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import { SocketProvider } from './SocketProvider.jsx';
 
 const root = ReactDOM.createRoot(document.getElementById('app'));
 root.render(
   <React.StrictMode>
-    <App />
+    <SocketProvider>
+      <App />
+    </SocketProvider>
   </React.StrictMode>
 );

--- a/frontend/test/loginForm.test.jsx
+++ b/frontend/test/loginForm.test.jsx
@@ -2,17 +2,22 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import LoginForm from '../src/components/LoginForm.jsx';
 import { attemptLogin } from '../../public/js/auth.js';
+import { SocketContext } from '../src/SocketProvider.jsx';
 
-vi.stubGlobal('socket', { emit: vi.fn() });
+const mockSocket = { emit: vi.fn() };
 vi.stubGlobal('attemptLogin', attemptLogin);
 
 beforeEach(() => {
-  socket.emit.mockClear();
+  mockSocket.emit.mockClear();
 });
 
 describe('LoginForm', () => {
   it('emits login event with entered credentials', () => {
-    render(<LoginForm onSwitch={() => {}} />);
+    render(
+      <SocketContext.Provider value={mockSocket}>
+        <LoginForm onSwitch={() => {}} />
+      </SocketContext.Provider>
+    );
     fireEvent.change(screen.getByPlaceholderText('Kullanıcı Adı'), {
       target: { value: 'alice' }
     });
@@ -20,6 +25,9 @@ describe('LoginForm', () => {
       target: { value: 'Secret1!' }
     });
     fireEvent.click(screen.getByText('Giriş Yap'));
-    expect(socket.emit).toHaveBeenCalledWith('login', { username: 'alice', password: 'Secret1!' });
+    expect(mockSocket.emit).toHaveBeenCalledWith('login', {
+      username: 'alice',
+      password: 'Secret1!'
+    });
   });
 });

--- a/frontend/test/registerForm.test.jsx
+++ b/frontend/test/registerForm.test.jsx
@@ -2,17 +2,22 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import RegisterForm from '../src/components/RegisterForm.jsx';
 import { attemptRegister } from '../../public/js/auth.js';
+import { SocketContext } from '../src/SocketProvider.jsx';
 
-vi.stubGlobal('socket', { emit: vi.fn() });
+const mockSocket = { emit: vi.fn() };
 vi.stubGlobal('attemptRegister', attemptRegister);
 
 beforeEach(() => {
-  socket.emit.mockClear();
+  mockSocket.emit.mockClear();
 });
 
 describe('RegisterForm', () => {
   it('emits register event with provided info', () => {
-    render(<RegisterForm onSwitch={() => {}} />);
+    render(
+      <SocketContext.Provider value={mockSocket}>
+        <RegisterForm onSwitch={() => {}} />
+      </SocketContext.Provider>
+    );
     fireEvent.change(screen.getByPlaceholderText('Kullanıcı Adı (küçük harf)'), {
       target: { value: 'bob' }
     });
@@ -26,7 +31,7 @@ describe('RegisterForm', () => {
     fireEvent.change(screen.getByPlaceholderText('Parola'), { target: { value: 'Secret1!' } });
     fireEvent.change(screen.getByPlaceholderText('Parola(Tekrar)'), { target: { value: 'Secret1!' } });
     fireEvent.click(screen.getByText('Kayıt Ol ve Başla'));
-    expect(socket.emit).toHaveBeenCalledWith('register', {
+    expect(mockSocket.emit).toHaveBeenCalledWith('register', {
       username: 'bob',
       name: 'Bob',
       surname: 'Builder',

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "socket.io": "^4.8.1",
+        "socket.io-client": "^4.8.1",
         "uuid": "^11.0.3",
         "winston": "^3.17.0",
         "ws": "^8.18.0"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "socket.io": "^4.8.1",
+    "socket.io-client": "^4.8.1",
     "uuid": "^11.0.3",
     "winston": "^3.17.0",
     "ws": "^8.18.0"

--- a/public/script.js
+++ b/public/script.js
@@ -532,8 +532,12 @@ window.addEventListener('DOMContentLoaded', () => {
 
   const socketURL = window.SOCKET_URL || window.location.origin;
   const savedToken = (() => { try { return localStorage.getItem('token'); } catch (e) { return null; } })();
-  socket = io(socketURL, { transports: ['websocket'], auth: savedToken ? { token: savedToken } : {} })
-  window.socket = socket;
+  if (window.socket) {
+    socket = window.socket;
+  } else {
+    socket = io(socketURL, { transports: ['websocket'], auth: savedToken ? { token: savedToken } : {} });
+    window.socket = socket;
+  }
   initSocketEvents(socket);
   initProfilePopout(socket);
   initUIEvents(socket);


### PR DESCRIPTION
## Summary
- add SocketProvider for React and expose socket on `window`
- wrap `<App />` in SocketProvider
- use SocketContext in LoginForm and RegisterForm
- skip socket creation if already defined in `public/script.js`
- update frontend tests for SocketProvider
- document new provider usage and dependency
- include `socket.io-client` in package.json

## Testing
- `npm test` *(fails: test suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_685fe19540948326b82f6d5d1b66da3a