### PR TITLE
Update CI Node.js version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
           cache: 'npm'
       - name: Install dependencies
         run: bash ./setup.sh


### PR DESCRIPTION
## Summary
- use Node.js 20 in `ci.yml`

## Testing
- `bash ./setup.sh` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685fe710f34083268428defb613739bf