### PR TITLE
Remove global auth helpers

### DIFF
--- a/frontend/src/auth.js
+++ b/frontend/src/auth.js
@@ -1,0 +1,1 @@
+export { attemptLogin, attemptRegister } from '../public/js/auth.js';

--- a/frontend/src/components/LoginForm.jsx
+++ b/frontend/src/components/LoginForm.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useContext } from 'react';
 import { SocketContext } from '../SocketProvider.jsx';
+import { attemptLogin } from '../auth.js';
 
 export default function LoginForm({ onSwitch }) {
   const [username, setUsername] = useState('');
@@ -13,7 +14,7 @@ export default function LoginForm({ onSwitch }) {
     e.preventDefault();
     setShakeUser(false);
     setShakePass(false);
-    const res = window.attemptLogin(socket, username, password);
+    const res = attemptLogin(socket, username, password);
     if (!res.ok) {
       setError(res.message || '');
       setShakeUser(true);

--- a/frontend/src/components/RegisterForm.jsx
+++ b/frontend/src/components/RegisterForm.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useContext } from 'react';
 import { SocketContext } from '../SocketProvider.jsx';
+import { attemptRegister } from '../auth.js';
 
 export default function RegisterForm({ onSwitch }) {
   const [username, setUsername] = useState('');
@@ -20,7 +21,7 @@ export default function RegisterForm({ onSwitch }) {
     setShakeUser(false);
     setShakePass(false);
     setShakePassConf(false);
-    const res = window.attemptRegister(socket, {
+    const res = attemptRegister(socket, {
       username,
       name,
       surname,

--- a/frontend/test/loginForm.test.jsx
+++ b/frontend/test/loginForm.test.jsx
@@ -1,11 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import LoginForm from '../src/components/LoginForm.jsx';
-import { attemptLogin } from '../../public/js/auth.js';
+import { attemptLogin } from '../src/auth.js';
 import { SocketContext } from '../src/SocketProvider.jsx';
 
 const mockSocket = { emit: vi.fn() };
-vi.stubGlobal('attemptLogin', attemptLogin);
 
 beforeEach(() => {
   mockSocket.emit.mockClear();

--- a/frontend/test/registerForm.test.jsx
+++ b/frontend/test/registerForm.test.jsx
@@ -1,11 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import RegisterForm from '../src/components/RegisterForm.jsx';
-import { attemptRegister } from '../../public/js/auth.js';
+import { attemptRegister } from '../src/auth.js';
 import { SocketContext } from '../src/SocketProvider.jsx';
 
 const mockSocket = { emit: vi.fn() };
-vi.stubGlobal('attemptRegister', attemptRegister);
 
 beforeEach(() => {
   mockSocket.emit.mockClear();

--- a/public/script.js
+++ b/public/script.js
@@ -70,10 +70,6 @@ import { showProfilePopout, initProfilePopout } from "./js/profilePopout.js";
 import { initAttachments } from "./js/attachments.js";
 import { attemptLogin, attemptRegister } from "./js/auth.js";
 
-// Expose auth helpers early so they are available even before DOMContentLoaded
-window.attemptLogin = attemptLogin;
-window.attemptRegister = attemptRegister;
-
 let socket = null;
 let device = null;   // mediasoup-client Device
 


### PR DESCRIPTION
## Summary
- export auth helpers from a new `frontend/src/auth.js`
- use these helpers in `LoginForm` and `RegisterForm`
- drop global assignments in `public/script.js`
- update React tests to import helpers from the new module

## Testing
- `npm test` *(fails: Cannot find module 'bcryptjs')*

------
https://chatgpt.com/codex/tasks/task_e_685fe94e69ec8326a2aa2c65ff4a8ca8