### PR TITLE
Fix screen share ended message

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1049,7 +1049,7 @@ window.showScreenShare = showScreenShare;
 
 /* displayScreenShareEndedMessage */
 function displayScreenShareEndedMessage(msg) {
-  const channelContentArea = document.querySelector('.channel-content-area');
+  const channelContentAreaElem = document.querySelector('.channel-content-area');
   let messageEl = document.getElementById('screenShareEndedMessage');
   if (!messageEl) {
     messageEl = document.createElement('div');
@@ -1065,8 +1065,9 @@ function displayScreenShareEndedMessage(msg) {
     messageEl.style.fontSize = '1.2rem';
   }
   messageEl.textContent = msg || 'Bu yayın sonlandırıldı';
-  const channelContentAreaElem = document.querySelector('.channel-content-area');
-  channelContentAreaElem.appendChild(messageEl);
+  if (channelContentAreaElem) {
+    channelContentAreaElem.appendChild(messageEl);
+  }
 }
 window.displayScreenShareEndedMessage = displayScreenShareEndedMessage;
 


### PR DESCRIPTION
## Summary
- check `.channel-content-area` before appending the screen share ended message

## Testing
- `npm run build` *(fails: `webpack` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686053a78588832693a4ad1028bfb48f