### PR TITLE
Initialize call screen on demand

### DIFF
--- a/frontend/src/components/CallScreen.jsx
+++ b/frontend/src/components/CallScreen.jsx
@@ -1,6 +1,11 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 export default function CallScreen() {
+  useEffect(() => {
+    if (window.initCallScreen) {
+      window.initCallScreen();
+    }
+  }, []);
   return (
     <div id="callScreen" className="screen-container" style={{ display: 'none' }}>
       {/* Soldaki Paneller */}

--- a/public/script.js
+++ b/public/script.js
@@ -347,7 +347,7 @@ window.applyAudioStates = (opts) => {
   }
   applyAudioStates(opts);
 };
-window.addEventListener('DOMContentLoaded', () => {
+function initCallScreen() {
   // Query DOM elements once the page has loaded
   groupListDiv = document.getElementById('groupList');
   createGroupButton = document.getElementById('createGroupButton');
@@ -572,6 +572,16 @@ window.addEventListener('DOMContentLoaded', () => {
       console.info('DM Filter clicked: ' + filter);
     }
   });
+}
+window.initCallScreen = initCallScreen;
+
+window.addEventListener('DOMContentLoaded', () => {
+  if (
+    document.getElementById('groupList') &&
+    document.getElementById('roomList')
+  ) {
+    initCallScreen();
+  }
 });
 
 /* Yeni fonksiyon: Context Menu Gösterimi */


### PR DESCRIPTION
## Summary
- wrap DOM queries and module setup in `initCallScreen`
- call `initCallScreen` only if required DOM nodes exist
- invoke the new initializer when `CallScreen` React component mounts

## Testing
- `npm test` *(fails: test suite requires network access)*

------
https://chatgpt.com/codex/tasks/task_e_68605741b1fc83268724c149cf36d120