### PR TITLE
Fix login screen by listening to socket events

### DIFF
--- a/frontend/src/components/RegisterForm.jsx
+++ b/frontend/src/components/RegisterForm.jsx
@@ -1,6 +1,7 @@
-import React, { useState, useContext } from 'react';
+import React, { useState, useContext, useEffect } from 'react';
 import { SocketContext } from '../SocketProvider.jsx';
 import { attemptRegister } from '../auth.js';
+import { ScreenContext } from '../App.jsx';
 
 export default function RegisterForm({ onSwitch }) {
   const [username, setUsername] = useState('');
@@ -16,6 +17,21 @@ export default function RegisterForm({ onSwitch }) {
   const [shakePass, setShakePass] = useState(false);
   const [shakePassConf, setShakePassConf] = useState(false);
   const socket = useContext(SocketContext);
+  const { setScreen } = useContext(ScreenContext);
+
+  useEffect(() => {
+    if (!socket) return;
+    const handleRegisterResult = (data) => {
+      if (data.success) {
+        alert('Hesap başarıyla oluşturuldu');
+        if (setScreen) setScreen('login');
+      } else {
+        setError(data.message || 'Kayıt hatası');
+      }
+    };
+    socket.on('registerResult', handleRegisterResult);
+    return () => socket.off('registerResult', handleRegisterResult);
+  }, [socket, setScreen]);
 
   const handleRegister = () => {
     setShakeUser(false);


### PR DESCRIPTION
## Summary
- hook into `loginResult` in the login form so users advance to the call screen
- watch `registerResult` in the register form so successful sign ups return to login

## Testing
- `npm test` *(fails: Cannot find module 'bcryptjs')*

------
https://chatgpt.com/codex/tasks/task_e_68606ceea8e88326897ba3d8d879fac0