### PR TITLE
Fix screen visibility and add test

### DIFF
--- a/frontend/src/components/CallScreen.jsx
+++ b/frontend/src/components/CallScreen.jsx
@@ -7,7 +7,7 @@ export default function CallScreen() {
     }
   }, []);
   return (
-    <div id="callScreen" className="screen-container" style={{ display: 'none' }}>
+    <div id="callScreen" className="screen-container">
       {/* Soldaki Paneller */}
       <div id="leftPanels" className="left-panels">
         <div id="groupsAndRooms" className="groups-rooms">

--- a/frontend/src/components/RegisterForm.jsx
+++ b/frontend/src/components/RegisterForm.jsx
@@ -60,7 +60,7 @@ export default function RegisterForm({ onSwitch }) {
   };
 
   return (
-    <div id="registerScreen" className="screen-container" style={{ display: 'none' }}>
+    <div id="registerScreen" className="screen-container">
       <div className="card">
         <h1 className="app-title">Kayıt Ol</h1>
         <p

--- a/frontend/test/appScreens.test.jsx
+++ b/frontend/test/appScreens.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import App from '../src/App.jsx';
 import { SocketContext } from '../src/SocketProvider.jsx';
 
@@ -18,5 +18,28 @@ describe('App screen switching', () => {
     expect(screen.getByText('Kayıt Ol')).toBeInTheDocument();
     fireEvent.click(screen.getByText('Geri Gel'));
     expect(screen.getByText('Oturum Aç')).toBeInTheDocument();
+  });
+
+  it('shows correct screen when calling setScreen', () => {
+    render(
+      <SocketContext.Provider value={mockSocket}>
+        <App />
+      </SocketContext.Provider>
+    );
+    expect(typeof window.setScreen).toBe('function');
+
+    act(() => {
+      window.setScreen('register');
+    });
+    const reg = document.getElementById('registerScreen');
+    expect(reg).not.toBeNull();
+    expect(reg.style.display).not.toBe('none');
+
+    act(() => {
+      window.setScreen('call');
+    });
+    const call = document.getElementById('callScreen');
+    expect(call).not.toBeNull();
+    expect(call.style.display).not.toBe('none');
   });
 });


### PR DESCRIPTION
## Summary
- show the call screen by default instead of styling it hidden
- show the register form when selected instead of hiding it with inline styles
- test `setScreen` shows the correct screen

## Testing
- `npm test` *(fails: Cannot find module 'bcryptjs')*

------
https://chatgpt.com/codex/tasks/task_e_6860732b91a88326b2d4c65e3e23f393