### PR TITLE
Set user card details on mount

### DIFF
--- a/frontend/src/components/CallScreen.jsx
+++ b/frontend/src/components/CallScreen.jsx
@@ -6,6 +6,21 @@ export default function CallScreen() {
       window.initCallScreen();
     }
   }, []);
+  useEffect(() => {
+    if (window.username) {
+      const nameEl = document.getElementById('userCardName');
+      if (nameEl) nameEl.textContent = window.username;
+      if (window.loadAvatar) {
+        window.loadAvatar(window.username).then((av) => {
+          const avatarEl = document.getElementById('userCardAvatar');
+          if (avatarEl) {
+            avatarEl.style.backgroundImage = `url(${av})`;
+            avatarEl.dataset.username = window.username;
+          }
+        });
+      }
+    }
+  }, []);
   return (
     <div id="callScreen" className="screen-container">
       {/* Soldaki Paneller */}


### PR DESCRIPTION
## Summary
- update CallScreen mount logic to populate username and avatar

## Testing
- `npm test` *(fails: Cannot find module 'bcryptjs')*

------
https://chatgpt.com/codex/tasks/task_e_68607e70e6d08326b3bcb2307986c9a2