### PR TITLE
Update login username handling

### DIFF
--- a/frontend/src/UserContext.jsx
+++ b/frontend/src/UserContext.jsx
@@ -1,0 +1,13 @@
+import React, { createContext, useState } from 'react';
+
+export const UserContext = createContext({ username: '', setUsername: () => {} });
+
+export function UserProvider({ children }) {
+  const [username, setUsername] = useState(window.username || '');
+
+  return (
+    <UserContext.Provider value={{ username, setUsername }}>
+      {children}
+    </UserContext.Provider>
+  );
+}

--- a/frontend/src/components/CallScreen.jsx
+++ b/frontend/src/components/CallScreen.jsx
@@ -1,26 +1,30 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState, useContext } from 'react';
+import { UserContext } from '../UserContext.jsx';
 
 export default function CallScreen() {
+  const { username: ctxUsername } = useContext(UserContext);
+  const [username, setUsername] = useState(window.username || '');
+
   useEffect(() => {
     if (window.initCallScreen) {
       window.initCallScreen();
     }
   }, []);
   useEffect(() => {
-    if (window.username) {
-      const nameEl = document.getElementById('userCardName');
-      if (nameEl) nameEl.textContent = window.username;
-      if (window.loadAvatar) {
-        window.loadAvatar(window.username).then((av) => {
-          const avatarEl = document.getElementById('userCardAvatar');
-          if (avatarEl) {
-            avatarEl.style.backgroundImage = `url(${av})`;
-            avatarEl.dataset.username = window.username;
-          }
-        });
-      }
+    if (ctxUsername) setUsername(ctxUsername);
+  }, [ctxUsername]);
+
+  useEffect(() => {
+    if (username && window.loadAvatar) {
+      window.loadAvatar(username).then((av) => {
+        const avatarEl = document.getElementById('userCardAvatar');
+        if (avatarEl) {
+          avatarEl.style.backgroundImage = `url(${av})`;
+          avatarEl.dataset.username = username;
+        }
+      });
     }
-  }, []);
+  }, [username]);
   return (
     <div id="callScreen" className="screen-container">
       {/* Soldaki Paneller */}
@@ -89,7 +93,7 @@ export default function CallScreen() {
           <div className="user-card">
             <div className="user-avatar" id="userCardAvatar"></div>
             <div className="user-info">
-              <span id="userCardName" className="user-name">(Kullanıcı)</span>
+              <span id="userCardName" className="user-name">{username || '(Kullanıcı)'}</span>
               <span id="userCardStatus" className="user-status">Çevrimdışı</span>
             </div>
             <button id="micToggleButton" className="icon-btn" title="Mikrofon Aç/Kapa"></button>

--- a/frontend/src/components/LoginForm.jsx
+++ b/frontend/src/components/LoginForm.jsx
@@ -2,6 +2,7 @@ import React, { useState, useContext, useEffect } from 'react';
 import { SocketContext } from '../SocketProvider.jsx';
 import { attemptLogin } from '../auth.js';
 import { ScreenContext } from '../App.jsx';
+import { UserContext } from '../UserContext.jsx';
 
 export default function LoginForm({ onSwitch }) {
   const [username, setUsername] = useState('');
@@ -11,12 +12,14 @@ export default function LoginForm({ onSwitch }) {
   const [shakePass, setShakePass] = useState(false);
   const socket = useContext(SocketContext);
   const { setScreen } = useContext(ScreenContext);
+  const { setUsername: setLoggedInUsername } = useContext(UserContext);
 
   useEffect(() => {
     if (!socket) return;
     const handleLoginResult = (data) => {
       if (data.success) {
         window.username = data.username;
+        if (setLoggedInUsername) setLoggedInUsername(data.username);
         try {
           localStorage.setItem('username', data.username);
           if (data.token) localStorage.setItem('token', data.token);
@@ -35,7 +38,7 @@ export default function LoginForm({ onSwitch }) {
     };
     socket.on('loginResult', handleLoginResult);
     return () => socket.off('loginResult', handleLoginResult);
-  }, [socket, setScreen]);
+  }, [socket, setScreen, setLoggedInUsername]);
 
   const handleSubmit = (e) => {
     e.preventDefault();

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -2,12 +2,15 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import { SocketProvider } from './SocketProvider.jsx';
+import { UserProvider } from './UserContext.jsx';
 
 const root = ReactDOM.createRoot(document.getElementById('app'));
 root.render(
   <React.StrictMode>
     <SocketProvider>
-      <App />
+      <UserProvider>
+        <App />
+      </UserProvider>
     </SocketProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- create a `UserContext` to hold the logged-in username
- wrap the app with `UserProvider`
- update `LoginForm` to set the username after a successful login
- use username state in `CallScreen` and display it in the user card

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_e_6860848551148326bb832fe60f57595f