### PR TITLE
Add UserCard component

### DIFF
--- a/frontend/src/components/CallScreen.jsx
+++ b/frontend/src/components/CallScreen.jsx
@@ -1,30 +1,12 @@
-import React, { useEffect, useState, useContext } from 'react';
-import { UserContext } from '../UserContext.jsx';
+import React, { useEffect } from 'react';
+import UserCard from './UserCard.jsx';
 
 export default function CallScreen() {
-  const { username: ctxUsername } = useContext(UserContext);
-  const [username, setUsername] = useState(window.username || '');
-
   useEffect(() => {
     if (window.initCallScreen) {
       window.initCallScreen();
     }
   }, []);
-  useEffect(() => {
-    if (ctxUsername) setUsername(ctxUsername);
-  }, [ctxUsername]);
-
-  useEffect(() => {
-    if (username && window.loadAvatar) {
-      window.loadAvatar(username).then((av) => {
-        const avatarEl = document.getElementById('userCardAvatar');
-        if (avatarEl) {
-          avatarEl.style.backgroundImage = `url(${av})`;
-          avatarEl.dataset.username = username;
-        }
-      });
-    }
-  }, [username]);
   return (
     <div id="callScreen" className="screen-container">
       {/* Soldaki Paneller */}
@@ -90,18 +72,7 @@ export default function CallScreen() {
             </button>
           </div>
           <div className="panel-divider"></div>
-          <div className="user-card">
-            <div className="user-avatar" id="userCardAvatar"></div>
-            <div className="user-info">
-              <span id="userCardName" className="user-name">{username || '(Kullanıcı)'}</span>
-              <span id="userCardStatus" className="user-status">Çevrimdışı</span>
-            </div>
-            <button id="micToggleButton" className="icon-btn" title="Mikrofon Aç/Kapa"></button>
-            <button id="deafenToggleButton" className="icon-btn" title="Kendini Sağırlaştır"></button>
-            <button id="settingsButton" className="icon-btn" title="Ayarlar">
-              <span className="material-icons">settings</span>
-            </button>
-          </div>
+          <UserCard />
         </div>
       </div>
       {/* Ortadaki Ana İçerik */}

--- a/frontend/src/components/UserCard.jsx
+++ b/frontend/src/components/UserCard.jsx
@@ -1,0 +1,43 @@
+import React, { useContext, useEffect, useState } from 'react';
+import { UserContext } from '../UserContext.jsx';
+
+export default function UserCard() {
+  const { username } = useContext(UserContext);
+  const [avatar, setAvatar] = useState('');
+
+  useEffect(() => {
+    let mounted = true;
+    if (username && window.loadAvatar) {
+      window.loadAvatar(username).then((url) => {
+        if (mounted) setAvatar(url);
+      });
+    }
+    return () => {
+      mounted = false;
+    };
+  }, [username]);
+
+  const avatarStyle = avatar ? { backgroundImage: `url(${avatar})` } : {};
+
+  return (
+    <div className="user-card">
+      <div
+        className="user-avatar"
+        id="userCardAvatar"
+        style={avatarStyle}
+        data-username={username || undefined}
+      ></div>
+      <div className="user-info">
+        <span id="userCardName" className="user-name">
+          {username || '(Kullanıcı)'}
+        </span>
+        <span id="userCardStatus" className="user-status">Çevrimdışı</span>
+      </div>
+      <button id="micToggleButton" className="icon-btn" title="Mikrofon Aç/Kapa"></button>
+      <button id="deafenToggleButton" className="icon-btn" title="Kendini Sağırlaştır"></button>
+      <button id="settingsButton" className="icon-btn" title="Ayarlar">
+        <span className="material-icons">settings</span>
+      </button>
+    </div>
+  );
+}

--- a/frontend/test/userCard.test.jsx
+++ b/frontend/test/userCard.test.jsx
@@ -1,0 +1,20 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import UserCard from '../src/components/UserCard.jsx';
+import { UserContext } from '../src/UserContext.jsx';
+
+beforeEach(() => {
+  window.loadAvatar = () => Promise.resolve('avatar.png');
+});
+
+describe('UserCard', () => {
+  it('renders username from context', () => {
+    const { container } = render(
+      <UserContext.Provider value={{ username: 'alice', setUsername: () => {} }}>
+        <UserCard />
+      </UserContext.Provider>
+    );
+    const nameEl = container.querySelector('#userCardName');
+    expect(nameEl.textContent).toBe('alice');
+  });
+});


### PR DESCRIPTION
## Summary
- migrate user card UI to a new React component
- load avatar asynchronously and display username from context
- use the new component inside `CallScreen`
- add a small test for `UserCard`

## Testing
- `npm test` *(fails: Cannot find module 'bcryptjs')*

------
https://chatgpt.com/codex/tasks/task_e_68608723e5b08326a71ec1ca4c9ca2aa