### PR TITLE
Move auth utils to frontend

### DIFF
--- a/frontend/src/auth.js
+++ b/frontend/src/auth.js
@@ -1,1 +1,56 @@
-export { attemptLogin, attemptRegister } from '../../public/js/auth.js';
+import logger from '../../public/utils/logger.js';
+
+export function attemptRegister(socket, fields) {
+  const usernameVal = (fields.username || '').trim();
+  const nameVal     = (fields.name || '').trim();
+  const surnameVal  = (fields.surname || '').trim();
+  const birthVal    = (fields.birthdate || '').trim();
+  const emailVal    = (fields.email || '').trim();
+  const phoneVal    = (fields.phone || '').trim();
+  const passVal     = (fields.password || '').trim();
+  const passConfVal = (fields.passwordConfirm || '').trim();
+
+  logger.info('🔐 attemptRegister tetiklendi');
+
+  if (!usernameVal || !nameVal || !surnameVal || !birthVal || !emailVal || !phoneVal || !passVal || !passConfVal) {
+    return { ok: false, message: 'Lütfen tüm alanları doldurunuz.' };
+  }
+
+  if (usernameVal !== usernameVal.toLowerCase()) {
+    return { ok: false, message: 'Kullanıcı adı sadece küçük harf olmalı!' };
+  }
+
+  if (passVal !== passConfVal) {
+    return { ok: false, message: 'Parolalar eşleşmiyor!' };
+  }
+
+  const complexityRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[\W_]).{8,}$/;
+  if (!complexityRegex.test(passVal)) {
+    return { ok: false, message: 'Parola en az 8 karakter, büyük/küçük harf, rakam ve özel karakter içermeli.' };
+  }
+
+  socket.emit('register', {
+    username: usernameVal,
+    name: nameVal,
+    surname: surnameVal,
+    birthdate: birthVal,
+    email: emailVal,
+    phone: phoneVal,
+    password: passVal,
+    passwordConfirm: passConfVal
+  });
+
+  return { ok: true };
+}
+
+export function attemptLogin(socket, username, password) {
+  const usernameVal = (username || '').trim();
+  const passwordVal = (password || '').trim();
+
+  if (!usernameVal || !passwordVal) {
+    return { ok: false, message: 'Lütfen gerekli alanları doldurunuz' };
+  }
+
+  socket.emit('login', { username: usernameVal, password: passwordVal });
+  return { ok: true };
+}

--- a/frontend/src/components/LoginForm.jsx
+++ b/frontend/src/components/LoginForm.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useContext, useEffect } from 'react';
 import { SocketContext } from '../SocketProvider.jsx';
-import { attemptLogin } from '../auth.js';
+import { attemptLogin } from '../auth';
 import { ScreenContext } from '../App.jsx';
 import { UserContext } from '../UserContext.jsx';
 

--- a/frontend/src/components/RegisterForm.jsx
+++ b/frontend/src/components/RegisterForm.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useContext, useEffect } from 'react';
 import { SocketContext } from '../SocketProvider.jsx';
-import { attemptRegister } from '../auth.js';
+import { attemptRegister } from '../auth';
 import { ScreenContext } from '../App.jsx';
 
 export default function RegisterForm({ onSwitch }) {


### PR DESCRIPTION
## Summary
- move browser auth helpers into React src
- point LoginForm and RegisterForm to the new module

## Testing
- `npm test` *(fails: test failure)*

------
https://chatgpt.com/codex/tasks/task_e_68608a2a30d08326b23eae21caf91779