### PR TITLE
Refactor CallScreen init logic into React hook

### DIFF
--- a/frontend/src/components/CallScreen.jsx
+++ b/frontend/src/components/CallScreen.jsx
@@ -1,12 +1,9 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import UserCard from './UserCard.jsx';
+import useCallScreenInit from '../useCallScreenInit.js';
 
 export default function CallScreen() {
-  useEffect(() => {
-    if (window.initCallScreen) {
-      window.initCallScreen();
-    }
-  }, []);
+  useCallScreenInit();
   return (
     <div id="callScreen" className="screen-container">
       {/* Soldaki Paneller */}

--- a/frontend/src/useCallScreenInit.js
+++ b/frontend/src/useCallScreenInit.js
@@ -1,0 +1,8 @@
+import { useEffect } from 'react';
+import { initCallScreen } from '../../public/script.js';
+
+export default function useCallScreenInit() {
+  useEffect(() => {
+    initCallScreen();
+  }, []);
+}

--- a/public/script.js
+++ b/public/script.js
@@ -347,7 +347,7 @@ window.applyAudioStates = (opts) => {
   }
   applyAudioStates(opts);
 };
-function initCallScreen() {
+export function initCallScreen() {
   // Query DOM elements once the page has loaded
   groupListDiv = document.getElementById('groupList');
   createGroupButton = document.getElementById('createGroupButton');
@@ -573,16 +573,6 @@ function initCallScreen() {
     }
   });
 }
-window.initCallScreen = initCallScreen;
-
-window.addEventListener('DOMContentLoaded', () => {
-  if (
-    document.getElementById('groupList') &&
-    document.getElementById('roomList')
-  ) {
-    initCallScreen();
-  }
-});
 
 /* Yeni fonksiyon: Context Menu Gösterimi */
 function showMuteSubMenu(target, type) {


### PR DESCRIPTION
## Summary
- export `initCallScreen` from `public/script.js` instead of exposing it on `window`
- create `useCallScreenInit` hook that calls `initCallScreen`
- use the new hook in `CallScreen` component

## Testing
- `npm test` *(fails: Cannot find module 'bcryptjs')*

------
https://chatgpt.com/codex/tasks/task_e_68608b46f68483268fe46527e043b505