### PR TITLE
Implement React-based group options modal

### DIFF
--- a/frontend/src/components/CallScreen.jsx
+++ b/frontend/src/components/CallScreen.jsx
@@ -1,11 +1,31 @@
 import React, { useEffect, useState } from 'react';
 import UserCard from './UserCard.jsx';
 import DMChat from './DMChat.jsx';
+import GroupOptionsModal from './GroupOptionsModal.jsx';
 import useCallScreenInit from '../useCallScreenInit.js';
 
 export default function CallScreen() {
   const [dmFriend, setDmFriend] = useState(null);
+  const [groupOptionsOpen, setGroupOptionsOpen] = useState(false);
   useCallScreenInit();
+
+  const openCreateGroup = () => {
+    const el = document.getElementById('actualGroupCreateModal');
+    if (el) {
+      el.style.display = 'flex';
+      el.classList.add('active');
+    }
+    setGroupOptionsOpen(false);
+  };
+
+  const openJoinGroup = () => {
+    const el = document.getElementById('joinGroupModal');
+    if (el) {
+      el.style.display = 'flex';
+      el.classList.add('active');
+    }
+    setGroupOptionsOpen(false);
+  };
   useEffect(() => {
     window.openDMChat = setDmFriend;
     return () => {
@@ -14,6 +34,12 @@ export default function CallScreen() {
   }, []);
   return (
     <div id="callScreen" className="screen-container">
+      <GroupOptionsModal
+        open={groupOptionsOpen}
+        onCreateGroup={openCreateGroup}
+        onJoinGroup={openJoinGroup}
+        onClose={() => setGroupOptionsOpen(false)}
+      />
       {/* Soldaki Paneller */}
       <div id="leftPanels" className="left-panels">
         <div id="groupsAndRooms" className="groups-rooms">
@@ -23,7 +49,11 @@ export default function CallScreen() {
               <span className="material-icons">forum</span>
             </button>
             <div id="groupList" className="group-list"></div>
-            <button id="createGroupButton" className="circle-btn create-group-btn">
+            <button
+              id="createGroupButton"
+              className="circle-btn create-group-btn"
+              onClick={() => setGroupOptionsOpen(true)}
+            >
               <span className="material-icons">add</span>
             </button>
           </div>

--- a/frontend/src/components/GroupOptionsModal.jsx
+++ b/frontend/src/components/GroupOptionsModal.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export default function GroupOptionsModal({ open, onCreateGroup, onJoinGroup, onClose }) {
+  const style = { display: open ? 'flex' : 'none' };
+  return (
+    <div id="groupModal" className="modal" style={style} onClick={(e) => { if (e.target.id === 'groupModal' && onClose) onClose(); }}>
+      <div className="modal-content">
+        <h2>Grup Seçenekleri</h2>
+        <button id="modalGroupCreateBtn" className="btn primary" onClick={onCreateGroup}>
+          Grup Kur
+        </button>
+        <button id="modalGroupJoinBtn" className="btn secondary" onClick={onJoinGroup}>
+          Gruba Katıl
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/public/index.html
+++ b/public/index.html
@@ -26,14 +26,6 @@
     <!-- DM Paneli -->
     <div id="dmPanel" class="dm-panel" style="display: none;"></div>
 
-    <!-- Modal: Grup Seçenekleri -->
-    <div id="groupModal" class="modal">
-      <div class="modal-content">
-        <h2>Grup Seçenekleri</h2>
-        <button id="modalGroupCreateBtn" class="btn primary">Grup Kur</button>
-        <button id="modalGroupJoinBtn" class="btn secondary">Gruba Katıl</button>
-      </div>
-    </div>
     <!-- Modal: Grup Kurma -->
     <div id="actualGroupCreateModal" class="modal">
       <div class="modal-content">


### PR DESCRIPTION
## Summary
- build `GroupOptionsModal` React component for group creation/join
- use the modal from `CallScreen` and manage it via state
- remove the old modal markup from `public/index.html`

## Testing
- `npm test` *(fails: Cannot find module 'bcryptjs')*

------
https://chatgpt.com/codex/tasks/task_e_68608fc045a48326a07f4adf221c0292