### PR TITLE
Add tests for new chat components

### DIFF
--- a/frontend/test/DMChat.test.jsx
+++ b/frontend/test/DMChat.test.jsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import DMChat from '../src/components/DMChat.jsx';
+import { SocketContext } from '../src/SocketProvider.jsx';
+
+let mockSocket;
+
+beforeEach(() => {
+  mockSocket = {
+    emit: vi.fn((event, data, cb) => {
+      if (cb) cb({ success: true, messages: [] });
+    }),
+    on: vi.fn(),
+    off: vi.fn()
+  };
+});
+
+describe('DMChat', () => {
+  it('sends message when send button clicked', () => {
+    const { container } = render(
+      <SocketContext.Provider value={mockSocket}>
+        <DMChat friend="bob" />
+      </SocketContext.Provider>
+    );
+    const input = container.querySelector('#dmMessageInput');
+    input.textContent = 'hello';
+    fireEvent.click(container.querySelector('#dmSendButton'));
+    expect(mockSocket.emit).toHaveBeenCalledWith(
+      'dmMessage',
+      { friend: 'bob', content: 'hello', attachments: [] },
+      expect.any(Function)
+    );
+  });
+
+  it('sends message on Enter key', () => {
+    const { container } = render(
+      <SocketContext.Provider value={mockSocket}>
+        <DMChat friend="alice" />
+      </SocketContext.Provider>
+    );
+    const input = container.querySelector('#dmMessageInput');
+    input.textContent = 'hey';
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(mockSocket.emit).toHaveBeenCalledWith(
+      'dmMessage',
+      { friend: 'alice', content: 'hey', attachments: [] },
+      expect.any(Function)
+    );
+  });
+});

--- a/frontend/test/GroupOptionsModal.test.jsx
+++ b/frontend/test/GroupOptionsModal.test.jsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import GroupOptionsModal from '../src/components/GroupOptionsModal.jsx';
+
+describe('GroupOptionsModal', () => {
+  it('triggers callbacks on interactions', () => {
+    const onCreate = vi.fn();
+    const onJoin = vi.fn();
+    const onClose = vi.fn();
+    const { container } = render(
+      <GroupOptionsModal
+        open={true}
+        onCreateGroup={onCreate}
+        onJoinGroup={onJoin}
+        onClose={onClose}
+      />
+    );
+    fireEvent.click(container.querySelector('#modalGroupCreateBtn'));
+    expect(onCreate).toHaveBeenCalled();
+    fireEvent.click(container.querySelector('#modalGroupJoinBtn'));
+    expect(onJoin).toHaveBeenCalled();
+    fireEvent.click(container.querySelector('#groupModal'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('is hidden when open is false', () => {
+    const { container } = render(<GroupOptionsModal open={false} />);
+    const modal = container.querySelector('#groupModal');
+    expect(modal.style.display).toBe('none');
+  });
+});


### PR DESCRIPTION
## Summary
- add DMChat tests covering send button and Enter key handling
- add GroupOptionsModal tests for button callbacks and visibility

## Testing
- `npm test` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68609125394483268b75696c6be04bf0