### PR TITLE
Expose initCallScreen globally

### DIFF
--- a/frontend/src/useCallScreenInit.js
+++ b/frontend/src/useCallScreenInit.js
@@ -1,8 +1,9 @@
 import { useEffect } from 'react';
-import { initCallScreen } from '../../public/script.js';
 
 export default function useCallScreenInit() {
   useEffect(() => {
-    initCallScreen();
+    if (typeof window.initCallScreen === 'function') {
+      window.initCallScreen();
+    }
   }, []);
 }

--- a/public/script.js
+++ b/public/script.js
@@ -1092,3 +1092,4 @@ window.removeScreenShareEndedMessage = removeScreenShareEndedMessage;
 
 window.openUserSettings = openUserSettings;
 window.closeUserSettings = closeUserSettings;
+window.initCallScreen = initCallScreen;


### PR DESCRIPTION
## Summary
- register `initCallScreen` on `window`
- use `window.initCallScreen()` from the React hook

## Testing
- `npm run build` *(fails: webpack not found)*
- `npm test` *(fails: cannot find module 'bcryptjs')*

------
https://chatgpt.com/codex/tasks/task_e_68609350f6ec8326884b435be8d66204