### PR TITLE
Add Babel loader configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,10 @@
     "vite": "^7.0.0",
     "vitest": "^3.2.4",
     "webpack": "^5.97.1",
-    "webpack-cli": "^6.0.1"
+    "webpack-cli": "^6.0.1",
+    "babel-loader": "^9.1.3",
+    "@babel/core": "^7.24.5",
+    "@babel/preset-env": "^7.24.5",
+    "@babel/preset-react": "^7.24.5"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,6 +26,20 @@ const clientBundleConfig = {
   output: {
     path: path.resolve(__dirname, 'public'),
     filename: 'bundle.js'
+  },
+  module: {
+    rules: [
+      {
+        test: /\.jsx?$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['@babel/preset-env', '@babel/preset-react']
+          }
+        }
+      }
+    ]
   }
 };
 


### PR DESCRIPTION
## Summary
- include babel loader presets in webpack config
- list React+Babel dev dependencies in package.json

## Testing
- `npm run build` *(fails: `webpack` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68609c9e91588326a3a41213ec853a66