### PR TITLE
Add user profile endpoint

### DIFF
--- a/frontend/src/components/ProfilePopout.jsx
+++ b/frontend/src/components/ProfilePopout.jsx
@@ -14,7 +14,7 @@ export default function ProfilePopout({ username, anchorX = 0, anchorY = 0, onCl
       });
     }
     const token = window.getAuthToken ? window.getAuthToken() : null;
-    fetch(`/api/user/me?username=${encodeURIComponent(username)}`, {
+    fetch(`/api/user/profile?username=${encodeURIComponent(username)}`, {
       headers: token ? { Authorization: `Bearer ${token}` } : undefined
     })
       .then((res) => (res.ok ? res.json() : null))

--- a/frontend/test/profilePopout.test.jsx
+++ b/frontend/test/profilePopout.test.jsx
@@ -10,7 +10,7 @@ beforeEach(() => {
     on: vi.fn(),
     off: vi.fn()
   };
-  global.fetch = vi.fn(() =>
+  global.fetch = vi.fn((url, opts) =>
     Promise.resolve({ ok: true, json: () => Promise.resolve({ displayName: 'alice', badges: [] }) })
   );
   window.loadAvatar = vi.fn(() => Promise.resolve('avatar1.png'));
@@ -24,6 +24,10 @@ describe('ProfilePopout', () => {
       <SocketContext.Provider value={mockSocket}>
         <ProfilePopout username="alice" anchorX={0} anchorY={0} />
       </SocketContext.Provider>
+    );
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/user/profile?username=alice',
+      { headers: undefined }
     );
     await waitFor(() => {
       const img = container.querySelector('.popout-avatar');

--- a/routes/user.js
+++ b/routes/user.js
@@ -92,6 +92,23 @@ module.exports = function createUserRouter(io) {
     }
   });
 
+  // GET /profile
+  router.get('/profile', async (req, res) => {
+    const username = req.query.username;
+    if (!username) return res.status(400).json({ error: 'missing username' });
+    try {
+      const user = await User.findOne({ username });
+      if (!user) return res.status(404).json({ error: 'not found' });
+      res.json({
+        displayName: user.name || '',
+        avatar: user.avatar || null,
+        badges: Array.isArray(user.badges) ? user.badges : []
+      });
+    } catch (err) {
+      res.status(500).json({ error: 'server error' });
+    }
+  });
+
   return router;
 };
 

--- a/test/userProfileRoute.test.js
+++ b/test/userProfileRoute.test.js
@@ -1,0 +1,42 @@
+const test = require('node:test');
+const assert = require('assert');
+process.env.JWT_SECRET = 'testsecret';
+const { sign } = require('../utils/jwt');
+
+function loadServer(User) {
+  const originalSetInterval = global.setInterval;
+  global.setInterval = () => ({ unref() {} });
+
+  delete require.cache[require.resolve('../models/User')];
+  require.cache[require.resolve('../models/User')] = { exports: User };
+  delete require.cache[require.resolve('../server')];
+  const serverModule = require('../server');
+
+  global.setInterval = originalSetInterval;
+  return serverModule;
+}
+
+test('GET /api/user/profile returns profile data for existing user', async () => {
+  process.env.NODE_ENV = 'test';
+  const userDoc = { username: 'alice', name: 'Alice', avatar: 'avatar.png', badges: ['x'] };
+  const User = { async findOne(q) { return q.username === 'alice' ? userDoc : null; } };
+  const { app } = loadServer(User);
+  const srv = app.listen(0);
+  const port = srv.address().port;
+
+  const token = sign({ username: 'bob' });
+
+  const res = await fetch(`http://localhost:${port}/api/user/profile?username=alice`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  const body = await res.json();
+
+  assert.strictEqual(res.status, 200);
+  assert.deepStrictEqual(body, {
+    displayName: 'Alice',
+    avatar: 'avatar.png',
+    badges: ['x']
+  });
+
+  srv.close();
+});


### PR DESCRIPTION
## Summary
- add `/api/user/profile` endpoint to return public profile info
- use the new endpoint in `ProfilePopout` component
- mock the new URL in ProfilePopout tests and verify fetch call
- add backend test for profile route

## Testing
- `npm test` *(fails: Cannot find module 'mongoose', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68613aeefb8c8326a7fa14480875114d