### PR TITLE
Add leaveDM cleanup event

### DIFF
--- a/frontend/src/components/DMChat.jsx
+++ b/frontend/src/components/DMChat.jsx
@@ -31,6 +31,7 @@ export default function DMChat({ friend }) {
     socket.on('newDMMessage', handleNew);
     socket.on('dmMessageDeleted', handleDeleted);
     return () => {
+      socket.emit('leaveDM', { friend });
       socket.off('newDMMessage', handleNew);
       socket.off('dmMessageDeleted', handleDeleted);
     };

--- a/frontend/test/DMChat.test.jsx
+++ b/frontend/test/DMChat.test.jsx
@@ -47,4 +47,14 @@ describe('DMChat', () => {
       expect.any(Function)
     );
   });
+
+  it('emits leaveDM on cleanup', () => {
+    const { unmount } = render(
+      <SocketContext.Provider value={mockSocket}>
+        <DMChat friend="carol" />
+      </SocketContext.Provider>
+    );
+    unmount();
+    expect(mockSocket.emit).toHaveBeenCalledWith('leaveDM', { friend: 'carol' });
+  });
 });

--- a/modules/dmChat.js
+++ b/modules/dmChat.js
@@ -25,6 +25,21 @@ module.exports = function registerDMChatEvents(socket, { io, User, DMMessage, us
     }
   });
 
+  socket.on('leaveDM', async ({ friend }, callback = () => {}) => {
+    const username = users[socket.id]?.username;
+    try {
+      if (!username || !friend) {
+        logger.warn('leaveDM failed: %s -> %s', username, friend);
+        return callback({ success: false });
+      }
+      socket.leave(getRoomName(username, friend));
+      callback({ success: true });
+    } catch (err) {
+      logger.error('leaveDM error: %o', err);
+      callback({ success: false });
+    }
+  });
+
   socket.on('getDMMessages', async ({ friend }, callback) => {
     const username = users[socket.id]?.username;
     try {


### PR DESCRIPTION
## Summary
- leave DM rooms on cleanup server-side
- emit `leaveDM` when DMChat unmounts or friend changes
- test that DMChat cleanup emits `leaveDM`

## Testing
- `npm test` *(fails: Cannot find module 'bcryptjs')*

------
https://chatgpt.com/codex/tasks/task_e_68613dad2ee083269ec417ab09d495b2