### PR TITLE
Implement React-based DM panel toggle

### DIFF
--- a/frontend/src/components/CallScreen.jsx
+++ b/frontend/src/components/CallScreen.jsx
@@ -8,6 +8,7 @@ import useCallScreenInit from '../useCallScreenInit.js';
 export default function CallScreen() {
   const [dmFriend, setDmFriend] = useState(null);
   const [groupOptionsOpen, setGroupOptionsOpen] = useState(false);
+  const [dmPanelOpen, setDmPanelOpen] = useState(false);
   useCallScreenInit();
 
   const openCreateGroup = () => {
@@ -41,13 +42,17 @@ export default function CallScreen() {
         onJoinGroup={openJoinGroup}
         onClose={() => setGroupOptionsOpen(false)}
       />
-      <DMPanel />
+      {dmPanelOpen && <DMPanel />}
       {/* Soldaki Paneller */}
       <div id="leftPanels" className="left-panels">
         <div id="groupsAndRooms" className="groups-rooms">
           {/* Sidebar (Gruplar) */}
           <div className="sidebar" id="sidebar">
-            <button id="toggleDMButton" className="circle-btn dm-toggle-btn">
+            <button
+              id="toggleDMButton"
+              className="circle-btn dm-toggle-btn"
+              onClick={() => setDmPanelOpen((o) => !o)}
+            >
               <span className="material-icons">forum</span>
             </button>
             <div id="groupList" className="group-list"></div>

--- a/frontend/test/DMPanel.test.jsx
+++ b/frontend/test/DMPanel.test.jsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import DMPanel from '../src/components/DMPanel.jsx';
+import CallScreen from '../src/components/CallScreen.jsx';
 import { SocketContext } from '../src/SocketProvider.jsx';
 
 let mockSocket;
@@ -27,5 +28,19 @@ describe('DMPanel', () => {
     const friendEl = await waitFor(() => getByText('alice'));
     fireEvent.click(friendEl);
     expect(window.openDMChat).toHaveBeenCalledWith('alice');
+  });
+
+  it('opens panel when toggle button clicked', () => {
+    const { container } = render(
+      <SocketContext.Provider value={mockSocket}>
+        <CallScreen />
+      </SocketContext.Provider>
+    );
+    const panelBefore = container.querySelector('#dmPanel');
+    expect(panelBefore).toBeNull();
+    const btn = container.querySelector('#toggleDMButton');
+    fireEvent.click(btn);
+    const panelAfter = container.querySelector('#dmPanel');
+    expect(panelAfter).not.toBeNull();
   });
 });

--- a/public/js/uiEvents.js
+++ b/public/js/uiEvents.js
@@ -316,40 +316,7 @@ export function initUIEvents(socket) {
     });
   }
 
-  toggleDMButton.addEventListener('click', () => {
-    window.removeScreenShareEndedMessage();
-    const channelContentArea = document.getElementById('channelContentArea');
-    const selectedChannelBar = document.getElementById('selectedChannelBar');
-    const selectedDMBar = document.getElementById('selectedDMBar');
-    const dmContentArea = document.getElementById('dmContentArea');
-    if (!window.isDMMode) {
-      roomPanel.style.display = 'none';
-      channelContentArea.style.display = 'none';
-      applyRightPanelState(false);
-      selectedChannelBar.style.display = 'none';
-      selectedDMBar.style.display = 'flex';
-      dmContentArea.style.display = 'flex';
-      toggleDMButton.querySelector('.material-icons').textContent = 'group';
-      window.isDMMode = true;
-    } else {
-      roomPanel.style.display = 'flex';
-      channelContentArea.style.display = 'flex';
-      const stored = (() => { try { return localStorage.getItem(RIGHT_PANEL_KEY) !== '0'; } catch (e) { return true; } })();
-      applyRightPanelState(stored);
-      selectedDMBar.style.display = 'none';
-      dmContentArea.style.display = 'none';
-      selectedChannelBar.style.display = 'flex';
-      toggleDMButton.querySelector('.material-icons').textContent = 'forum';
-      selectedChannelTitle.textContent = 'Kanal Seçilmedi';
-      window.isDMMode = false;
-      const messages = document.getElementById('textMessages');
-      const chatInput = document.getElementById('textChannelMessageInput');
-      const chatBar = document.getElementById('textChatInputBar');
-      if (messages) messages.style.width = '';
-      if (chatInput) chatInput.style.width = '';
-      if (chatBar) chatBar.style.width = '';
-    }
-  });
+  // DM panel toggle is now controlled by React
 
   if (toggleUserListButton) {
     toggleUserListButton.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- manage DMPanel visibility via React state in `CallScreen`
- remove legacy DM toggle logic from `uiEvents.js`
- test DM panel toggle behaviour

## Testing
- `npm test --silent` *(fails: Cannot find module 'dompurify', 'mongoose', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686142e1e828832692656478cbf96441