### PR TITLE
Migrate group modals to React

### DIFF
--- a/frontend/src/components/CallScreen.jsx
+++ b/frontend/src/components/CallScreen.jsx
@@ -1,34 +1,42 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useContext } from 'react';
 import UserCard from './UserCard.jsx';
 import DMChat from './DMChat.jsx';
 import TextChannel from './TextChannel.jsx';
 import DMPanel from './DMPanel.jsx';
 import GroupOptionsModal from './GroupOptionsModal.jsx';
+import CreateGroupModal from './CreateGroupModal.jsx';
+import JoinGroupModal from './JoinGroupModal.jsx';
 import UserList from './UserList.jsx';
 import useCallScreenInit from '../useCallScreenInit.js';
+import { SocketContext } from '../SocketProvider.jsx';
 
 export default function CallScreen() {
+  const socket = useContext(SocketContext);
   const [dmFriend, setDmFriend] = useState(null);
   const [groupOptionsOpen, setGroupOptionsOpen] = useState(false);
   const [dmPanelOpen, setDmPanelOpen] = useState(false);
+  const [createGroupOpen, setCreateGroupOpen] = useState(false);
+  const [joinGroupOpen, setJoinGroupOpen] = useState(false);
   useCallScreenInit();
 
   const openCreateGroup = () => {
-    const el = document.getElementById('actualGroupCreateModal');
-    if (el) {
-      el.style.display = 'flex';
-      el.classList.add('active');
-    }
+    setCreateGroupOpen(true);
     setGroupOptionsOpen(false);
   };
 
   const openJoinGroup = () => {
-    const el = document.getElementById('joinGroupModal');
-    if (el) {
-      el.style.display = 'flex';
-      el.classList.add('active');
-    }
+    setJoinGroupOpen(true);
     setGroupOptionsOpen(false);
+  };
+
+  const handleCreateGroup = (name, channel) => {
+    if (socket) socket.emit('createGroup', { groupName: name, channelName: channel });
+    setCreateGroupOpen(false);
+  };
+
+  const handleJoinGroup = (gid) => {
+    if (socket) socket.emit('joinGroup', gid);
+    setJoinGroupOpen(false);
   };
   useEffect(() => {
     window.openDMChat = setDmFriend;
@@ -43,6 +51,16 @@ export default function CallScreen() {
         onCreateGroup={openCreateGroup}
         onJoinGroup={openJoinGroup}
         onClose={() => setGroupOptionsOpen(false)}
+      />
+      <CreateGroupModal
+        open={createGroupOpen}
+        onSubmit={handleCreateGroup}
+        onClose={() => setCreateGroupOpen(false)}
+      />
+      <JoinGroupModal
+        open={joinGroupOpen}
+        onSubmit={handleJoinGroup}
+        onClose={() => setJoinGroupOpen(false)}
       />
       {dmPanelOpen && <DMPanel />}
       {/* Soldaki Paneller */}

--- a/frontend/src/components/CreateGroupModal.jsx
+++ b/frontend/src/components/CreateGroupModal.jsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+
+export default function CreateGroupModal({ open, onSubmit, onClose }) {
+  const [name, setName] = useState('');
+  const style = { display: open ? 'flex' : 'none' };
+
+  const handleSubmit = () => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    const channel = window.prompt('Metin kanalı adı:', 'general');
+    if (channel && channel.trim() !== '') {
+      if (onSubmit) onSubmit(trimmed, channel.trim());
+      setName('');
+    }
+  };
+
+  const handleOverlay = (e) => {
+    if (e.target.id === 'actualGroupCreateModal' && onClose) onClose();
+  };
+
+  return (
+    <div
+      id="actualGroupCreateModal"
+      className="modal"
+      style={style}
+      onClick={handleOverlay}
+    >
+      <div className="modal-content">
+        <h2>Yeni Grup Kur</h2>
+        <input
+          type="text"
+          id="actualGroupName"
+          className="input-text"
+          placeholder="Grup Adı"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <div className="modal-buttons">
+          <button
+            id="actualGroupNameBtn"
+            className="btn primary"
+            onClick={handleSubmit}
+          >
+            Oluştur
+          </button>
+          <button
+            id="closeCreateGroupModal"
+            className="btn secondary"
+            onClick={onClose}
+          >
+            Kapat
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/JoinGroupModal.jsx
+++ b/frontend/src/components/JoinGroupModal.jsx
@@ -1,0 +1,41 @@
+import React, { useState } from 'react';
+
+export default function JoinGroupModal({ open, onSubmit, onClose }) {
+  const [groupId, setGroupId] = useState('');
+  const style = { display: open ? 'flex' : 'none' };
+
+  const handleSubmit = () => {
+    const gid = groupId.trim();
+    if (!gid) return;
+    if (onSubmit) onSubmit(gid);
+    setGroupId('');
+  };
+
+  const handleOverlay = (e) => {
+    if (e.target.id === 'joinGroupModal' && onClose) onClose();
+  };
+
+  return (
+    <div id="joinGroupModal" className="modal" style={style} onClick={handleOverlay}>
+      <div className="modal-content">
+        <h2>Gruba Katıl</h2>
+        <input
+          type="text"
+          id="joinGroupIdInput"
+          className="input-text"
+          placeholder="Grup ID"
+          value={groupId}
+          onChange={(e) => setGroupId(e.target.value)}
+        />
+        <div className="modal-buttons">
+          <button id="joinGroupIdBtn" className="btn primary" onClick={handleSubmit}>
+            Gruba Katıl
+          </button>
+          <button id="closeJoinGroupModal" className="btn secondary" onClick={onClose}>
+            Kapat
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/test/CreateGroupModal.test.jsx
+++ b/frontend/test/CreateGroupModal.test.jsx
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import CreateGroupModal from '../src/components/CreateGroupModal.jsx';
+
+beforeEach(() => {
+  window.prompt = vi.fn(() => 'general');
+});
+
+describe('CreateGroupModal', () => {
+  it('calls onSubmit with entered name', () => {
+    const onSubmit = vi.fn();
+    const { container } = render(
+      <CreateGroupModal open={true} onSubmit={onSubmit} onClose={() => {}} />
+    );
+    fireEvent.change(container.querySelector('#actualGroupName'), {
+      target: { value: 'mygroup' }
+    });
+    fireEvent.click(container.querySelector('#actualGroupNameBtn'));
+    expect(onSubmit).toHaveBeenCalledWith('mygroup', 'general');
+  });
+
+  it('is hidden when open is false', () => {
+    const { container } = render(<CreateGroupModal open={false} />);
+    const modal = container.querySelector('#actualGroupCreateModal');
+    expect(modal.style.display).toBe('none');
+  });
+});

--- a/frontend/test/JoinGroupModal.test.jsx
+++ b/frontend/test/JoinGroupModal.test.jsx
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import JoinGroupModal from '../src/components/JoinGroupModal.jsx';
+
+describe('JoinGroupModal', () => {
+  it('calls onSubmit with entered id', () => {
+    const onSubmit = vi.fn();
+    const { container } = render(
+      <JoinGroupModal open={true} onSubmit={onSubmit} onClose={() => {}} />
+    );
+    fireEvent.change(container.querySelector('#joinGroupIdInput'), {
+      target: { value: 'g1' }
+    });
+    fireEvent.click(container.querySelector('#joinGroupIdBtn'));
+    expect(onSubmit).toHaveBeenCalledWith('g1');
+  });
+
+  it('is hidden when open is false', () => {
+    const { container } = render(<JoinGroupModal open={false} />);
+    const modal = container.querySelector('#joinGroupModal');
+    expect(modal.style.display).toBe('none');
+  });
+});

--- a/frontend/test/callScreen.test.jsx
+++ b/frontend/test/callScreen.test.jsx
@@ -1,11 +1,44 @@
-import { describe, it, expect } from 'vitest';
-import { render } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
 import CallScreen from '../src/components/CallScreen.jsx';
+import { SocketContext } from '../src/SocketProvider.jsx';
 
 describe('CallScreen', () => {
   it('renders call screen container', () => {
     const { container } = render(<CallScreen />);
     const el = container.querySelector('#callScreen');
     expect(el).not.toBeNull();
+  });
+
+  it('handles group modal interactions', () => {
+    const mockSocket = { emit: vi.fn() };
+    window.prompt = vi.fn(() => 'ch');
+    const { container } = render(
+      <SocketContext.Provider value={mockSocket}>
+        <CallScreen />
+      </SocketContext.Provider>
+    );
+    fireEvent.click(container.querySelector('#createGroupButton'));
+    fireEvent.click(container.querySelector('#modalGroupCreateBtn'));
+    const cg = container.querySelector('#actualGroupCreateModal');
+    expect(cg.style.display).toBe('flex');
+    fireEvent.change(container.querySelector('#actualGroupName'), {
+      target: { value: 'grp' }
+    });
+    fireEvent.click(container.querySelector('#actualGroupNameBtn'));
+    expect(mockSocket.emit).toHaveBeenCalledWith('createGroup', {
+      groupName: 'grp',
+      channelName: 'ch'
+    });
+
+    fireEvent.click(container.querySelector('#createGroupButton'));
+    fireEvent.click(container.querySelector('#modalGroupJoinBtn'));
+    const jg = container.querySelector('#joinGroupModal');
+    expect(jg.style.display).toBe('flex');
+    fireEvent.change(container.querySelector('#joinGroupIdInput'), {
+      target: { value: 'gid' }
+    });
+    fireEvent.click(container.querySelector('#joinGroupIdBtn'));
+    expect(mockSocket.emit).toHaveBeenCalledWith('joinGroup', 'gid');
   });
 });

--- a/public/index.html
+++ b/public/index.html
@@ -26,28 +26,6 @@
     <!-- DM Paneli -->
     <div id="dmPanel" class="dm-panel" style="display: none;"></div>
 
-    <!-- Modal: Grup Kurma -->
-    <div id="actualGroupCreateModal" class="modal">
-      <div class="modal-content">
-        <h2>Yeni Grup Kur</h2>
-        <input type="text" id="actualGroupName" class="input-text" placeholder="Grup Adı" />
-        <div class="modal-buttons">
-          <button id="actualGroupNameBtn" class="btn primary">Oluştur</button>
-          <button id="closeCreateGroupModal" class="btn secondary">Kapat</button>
-        </div>
-      </div>
-    </div>
-    <!-- Modal: Gruba Katıl -->
-    <div id="joinGroupModal" class="modal">
-      <div class="modal-content">
-        <h2>Gruba Katıl</h2>
-        <input type="text" id="joinGroupIdInput" class="input-text" placeholder="Grup ID" />
-        <div class="modal-buttons">
-          <button id="joinGroupIdBtn" class="btn primary">Gruba Katıl</button>
-          <button id="closeJoinGroupModal" class="btn secondary">Kapat</button>
-        </div>
-      </div>
-    </div>
     <!-- Modal: Grup Ayarları -->
     <div id="groupSettingsModal" class="modal">
       <div class="modal-content">

--- a/public/js/uiEvents.js
+++ b/public/js/uiEvents.js
@@ -225,49 +225,7 @@ export function initUIEvents(socket) {
     });
   }
 
-  if (modalGroupCreateBtn) {
-    modalGroupCreateBtn.addEventListener('click', () => {
-      if (groupModal) {
-        groupModal.style.display = 'none';
-        groupModal.classList.remove('active');
-      }
-      if (actualGroupCreateModal) {
-        actualGroupCreateModal.style.display = 'flex';
-        actualGroupCreateModal.classList.add('active');
-      }
-    });
-  }
-
-  if (modalGroupJoinBtn) {
-    modalGroupJoinBtn.addEventListener('click', () => {
-      if (groupModal) {
-        groupModal.style.display = 'none';
-        groupModal.classList.remove('active');
-      }
-      if (joinGroupModal) {
-        joinGroupModal.style.display = 'flex';
-        joinGroupModal.classList.add('active');
-      }
-    });
-  }
-
-  if (closeCreateGroupModal) {
-    closeCreateGroupModal.addEventListener('click', () => {
-      if (actualGroupCreateModal) {
-        actualGroupCreateModal.style.display = 'none';
-        actualGroupCreateModal.classList.remove('active');
-      }
-    });
-  }
-
-  if (closeJoinGroupModal) {
-    closeJoinGroupModal.addEventListener('click', () => {
-      if (joinGroupModal) {
-        joinGroupModal.style.display = 'none';
-        joinGroupModal.classList.remove('active');
-      }
-    });
-  }
+  // create/join group handled by React
 
   if (closeGroupSettingsModal) {
     closeGroupSettingsModal.addEventListener('click', () => {
@@ -288,32 +246,7 @@ export function initUIEvents(socket) {
     });
   }
 
-  if (actualGroupNameBtn) {
-    actualGroupNameBtn.addEventListener('click', () => {
-      const name = actualGroupName ? actualGroupName.value.trim() : '';
-      if (!name) return;
-      const channelName = prompt('Metin kanalı adı:', 'general');
-      if (channelName && channelName.trim() !== '') {
-        socket.emit('createGroup', {
-          groupName: name,
-          channelName: channelName.trim()
-        });
-        actualGroupName.value = '';
-        if (actualGroupCreateModal) actualGroupCreateModal.style.display = 'none';
-      }
-    });
-  }
-
-  if (joinGroupIdBtn) {
-    joinGroupIdBtn.addEventListener('click', () => {
-      const gid = joinGroupIdInput ? joinGroupIdInput.value.trim() : '';
-      if (gid) {
-        socket.emit('joinGroup', gid);
-        joinGroupIdInput.value = '';
-        if (joinGroupModal) joinGroupModal.style.display = 'none';
-      }
-    });
-  }
+  // create/join group handled by React
 
   // DM panel toggle is now controlled by React
 


### PR DESCRIPTION
## Summary
- create `CreateGroupModal` and `JoinGroupModal` React components
- use them from `CallScreen` instead of DOM elements
- strip old DOM markup from `public/index.html`
- drop modal logic from `uiEvents.js`
- add unit tests for the new modals and update call screen tests

## Testing
- `npm test` *(fails: Cannot find module 'bcryptjs')*

------
https://chatgpt.com/codex/tasks/task_e_6861492d06b883269e599bf4ca4b80cc