### PR TITLE
Fix screen share cleanup removal

### DIFF
--- a/public/js/socketEvents.js
+++ b/public/js/socketEvents.js
@@ -1768,16 +1768,16 @@ export function initSocketEvents(socket) {
     const channelContentArea = document.querySelector('.channel-content-area');
     if (
       WebRTC.screenShareContainer &&
-      channelContentArea &&
-      channelContentArea.contains(WebRTC.screenShareContainer)
+      WebRTC.screenShareContainer.parentNode
     ) {
-      channelContentArea.removeChild(WebRTC.screenShareContainer);
+      WebRTC.screenShareContainer.parentNode.removeChild(
+        WebRTC.screenShareContainer,
+      );
     } else if (
       WebRTC.screenShareVideo &&
-      channelContentArea &&
-      channelContentArea.contains(WebRTC.screenShareVideo)
+      WebRTC.screenShareVideo.parentNode
     ) {
-      channelContentArea.removeChild(WebRTC.screenShareVideo);
+      WebRTC.screenShareVideo.parentNode.removeChild(WebRTC.screenShareVideo);
     }
     if (
       window.screenShareVideo &&
@@ -1787,6 +1787,12 @@ export function initSocketEvents(socket) {
     }
     window.screenShareVideo = null;
     window.screenShareContainer = null;
+    if (typeof WebRTC.setScreenShareVideo === 'function') {
+      WebRTC.setScreenShareVideo(null);
+    }
+    if (typeof WebRTC.setScreenShareContainer === 'function') {
+      WebRTC.setScreenShareContainer(null);
+    }
     const message =
       userId === socket.id
         ? 'Yayınınız sonlandırıldı'


### PR DESCRIPTION
## Summary
- fix screen share cleanup in `screenShareEnded` listener
- null out WebRTC screen share variables after cleanup

## Testing
- `npm test` *(fails: Cannot find module 'bcryptjs')*

------
https://chatgpt.com/codex/tasks/task_e_6861600782dc8326a5fc60295833b077