### PR TITLE
Fix voice channel full view

### DIFF
--- a/frontend/src/components/TextChannel.jsx
+++ b/frontend/src/components/TextChannel.jsx
@@ -162,7 +162,11 @@ export default function TextChannel() {
     <div
       id="textChannelContainer"
       className="text-channel-container"
-      style={{ display: channelId ? 'flex' : 'none', flexDirection: 'column' }}
+      style={{
+        display:
+          channelId && window.currentRoomType !== 'voice' ? 'flex' : 'none',
+        flexDirection: 'column',
+      }}
     >
       <div id="textMessages" className="text-messages" style={{ flex: 1 }}>
         {messages.map((msg, idx) => {


### PR DESCRIPTION
## Summary
- avoid showing text channel while a voice channel is active

## Testing
- `npm test` *(fails: ENOAUDIT / network)*

------
https://chatgpt.com/codex/tasks/task_e_686170829bdc83268daec996de9ea1c3