### PR TITLE
Fix text channel not filling width

### DIFF
--- a/frontend/src/components/TextChannel.jsx
+++ b/frontend/src/components/TextChannel.jsx
@@ -165,6 +165,7 @@ export default function TextChannel() {
       style={{
         display:
           channelId && window.currentRoomType !== 'voice' ? 'flex' : 'none',
+        flex: 1,
         flexDirection: 'column',
       }}
     >

--- a/public/style/components/chat.css
+++ b/public/style/components/chat.css
@@ -2,6 +2,7 @@
 .text-channel-container,
 #dmContentArea {
   display: flex;
+  flex: 1;
   flex-direction: column;
   justify-content: space-between;
   min-width: 0;


### PR DESCRIPTION
## Summary
- make `.text-channel-container` flexible so it spans the available width
- ensure React `<TextChannel>` container uses `flex: 1`

## Testing
- `npm test` *(fails: test suite cannot run in container)*

------
https://chatgpt.com/codex/tasks/task_e_6861760421788326b10afbc4f73f90f3