### PR TITLE
Add avatars to text messages

### DIFF
--- a/frontend/src/components/DMChat.jsx
+++ b/frontend/src/components/DMChat.jsx
@@ -1,5 +1,6 @@
 import React, { useContext, useEffect, useRef, useState } from 'react';
 import { SocketContext } from '../SocketProvider.jsx';
+import MessageItem from './MessageItem.jsx';
 
 export default function DMChat({ friend, dmActive }) {
   const socket = useContext(SocketContext);
@@ -67,21 +68,7 @@ export default function DMChat({ friend, dmActive }) {
     >
       <div id="dmMessages" className="text-messages" style={{ flex: 1 }}>
         {messages.map((msg) => (
-          <div key={msg.id || msg._id} className="text-message">
-            <div className="message-item" style={{ position: 'relative' }}>
-              <span className="sender-name">{msg.username || msg.user?.username}</span>
-              <div className="message-content">{msg.content}</div>
-              {Array.isArray(msg.attachments) && msg.attachments.length > 0 && (
-                <div className="message-attachments">
-                  {msg.attachments.map((a) => (
-                    <a key={a.id} href={a.url} target="_blank" rel="noopener noreferrer">
-                      {a.name || a.url}
-                    </a>
-                  ))}
-                </div>
-              )}
-            </div>
-          </div>
+          <MessageItem key={msg.id || msg._id} msg={msg} />
         ))}
       </div>
       <div id="dmTextChatInputBar" className="text-chat-input-bar">

--- a/frontend/src/components/MessageItem.jsx
+++ b/frontend/src/components/MessageItem.jsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useState, useContext } from 'react';
+import { SocketContext } from '../SocketProvider.jsx';
+
+export default function MessageItem({ msg, time }) {
+  const socket = useContext(SocketContext);
+  const username = msg.username || (msg.user && msg.user.username) || '';
+  const [avatar, setAvatar] = useState('/images/default-avatar.png');
+
+  useEffect(() => {
+    let active = true;
+    if (username && window.loadAvatar) {
+      window.loadAvatar(username).then((url) => {
+        if (active && url) setAvatar(url);
+      });
+    }
+    const handle = ({ username: u, avatar: av }) => {
+      if (u === username) setAvatar(av || '/images/default-avatar.png');
+    };
+    if (socket) socket.on('avatarUpdated', handle);
+    return () => {
+      active = false;
+      if (socket) socket.off('avatarUpdated', handle);
+    };
+  }, [username, socket]);
+
+  const avatarStyle = { backgroundImage: `url(${avatar})` };
+
+  return (
+    <div className="text-message">
+      <div className="message-item" style={{ position: 'relative' }}>
+        <div className="message-avatar-container">
+          <div className="message-avatar" style={avatarStyle}></div>
+        </div>
+        <div className="sender-info">
+          <span className="sender-name">{username}</span>
+          {time && <span className="timestamp">{time}</span>}
+        </div>
+        <div className="message-content">{msg.content}</div>
+        {Array.isArray(msg.attachments) && msg.attachments.length > 0 && (
+          <div className="message-attachments">
+            {msg.attachments.map((a) => (
+              <a key={a.id} href={a.url} target="_blank" rel="noreferrer">
+                {a.name || a.url}
+              </a>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/TextChannel.jsx
+++ b/frontend/src/components/TextChannel.jsx
@@ -2,6 +2,7 @@ import React, { useContext, useEffect, useRef, useState } from 'react';
 import { SocketContext } from '../SocketProvider.jsx';
 import { UserContext } from '../UserContext.jsx';
 import AttachmentPreview from './AttachmentPreview.jsx';
+import MessageItem from './MessageItem.jsx';
 
 function isDifferentDay(a, b) {
   const d1 = new Date(a);
@@ -180,22 +181,7 @@ export default function TextChannel() {
                   <span className="separator-text">{formatLongDate(msg.timestamp)}</span>
                 </div>
               )}
-              <div className="text-message">
-                <div className="message-item" style={{ position: 'relative' }}>
-                  <span className="sender-name">{msg.username || msg.user?.username}</span>
-                  <span className="timestamp">{formatTimestamp(msg.timestamp)}</span>
-                  <div className="message-content">{msg.content}</div>
-                  {Array.isArray(msg.attachments) && msg.attachments.length > 0 && (
-                    <div className="message-attachments">
-                      {msg.attachments.map(a => (
-                        <a key={a.id} href={a.url} target="_blank" rel="noreferrer">
-                          {a.name || a.url}
-                        </a>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              </div>
+              <MessageItem msg={msg} time={formatTimestamp(msg.timestamp)} />
             </React.Fragment>
           );
         })}


### PR DESCRIPTION
## Summary
- show avatars beside sender names in DM and text channel messages
- factor message rendering into a reusable `MessageItem` component

## Testing
- `npm --silent test` *(fails: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_e_68617965791c8326ae44761d28f3873a