### PR TITLE
Remove obsolete group creation handler

### DIFF
--- a/public/js/uiEvents.js
+++ b/public/js/uiEvents.js
@@ -216,15 +216,6 @@ export function initUIEvents(socket) {
     });
   }
 
-  if (createGroupButton) {
-    createGroupButton.addEventListener('click', () => {
-      if (groupModal) {
-        groupModal.style.display = 'flex';
-        groupModal.classList.add('active');
-      }
-    });
-  }
-
   // create/join group handled by React
 
   if (closeGroupSettingsModal) {


### PR DESCRIPTION
## Summary
- drop createGroupButton listener leftover from old UI

## Testing
- `npm test` *(fails: test framework cannot run)*

------
https://chatgpt.com/codex/tasks/task_e_68617fb08f5c832695cc13a8f07d33bb