### PR TITLE
Move profile popout provider

### DIFF
--- a/frontend/src/ProfilePopoutProvider.jsx
+++ b/frontend/src/ProfilePopoutProvider.jsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useState, useCallback } from 'react';
 import { createPortal } from 'react-dom';
-import ProfilePopout from '../../frontend/src/components/ProfilePopout.jsx';
+import ProfilePopout from './components/ProfilePopout.jsx';
 
 export const ProfilePopoutContext = createContext({
   openPopout: () => {},

--- a/frontend/src/components/UserList.jsx
+++ b/frontend/src/components/UserList.jsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { SocketContext } from '../SocketProvider.jsx';
-import { useProfilePopout } from '../../../public/js/profilePopout.js';
+import { useProfilePopout } from '../ProfilePopoutProvider.jsx';
 
 function UserItem({ username }) {
   const socket = useContext(SocketContext);

--- a/frontend/test/UserList.test.jsx
+++ b/frontend/test/UserList.test.jsx
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, waitFor } from '@testing-library/react';
 import UserList from '../src/components/UserList.jsx';
 import { SocketContext } from '../src/SocketProvider.jsx';
-import { ProfilePopoutProvider } from '../../public/js/profilePopout.js';
+import { ProfilePopoutProvider } from '../src/ProfilePopoutProvider.jsx';
 
 let handlers;
 let mockSocket;

--- a/public/script.js
+++ b/public/script.js
@@ -63,7 +63,6 @@ import { initSocketEvents } from "./js/socketEvents.js";
 import * as WebRTC from "./js/webrtc.js";
 import { applyAudioStates } from "./js/audioUtils.js";
 import { initUserSettings, openUserSettings, closeUserSettings } from "./js/userSettings.js";
-import { showProfilePopout, initProfilePopout } from "./js/profilePopout.js";
 import { attemptLogin, attemptRegister } from "../frontend/src/auth.js";
 
 let socket = null;
@@ -512,7 +511,6 @@ export function initCallScreen() {
     window.socket = socket;
   }
   initSocketEvents(socket);
-  initProfilePopout(socket);
   initUIEvents(socket);
   initFriendRequests(socket);
   initUserSettings();


### PR DESCRIPTION
## Summary
- migrate profile popout provider into frontend src
- use the new provider path in UserList and its tests
- drop leftover profile popout init from public script

## Testing
- `npm run build` *(fails: webpack not found)*
- `npm test` *(fails: cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_6861843a96c4832682f846b8c357b8dd