### PR TITLE
Hide voice sections until joining a channel

### DIFF
--- a/frontend/src/components/CallScreen.jsx
+++ b/frontend/src/components/CallScreen.jsx
@@ -101,6 +101,11 @@ export default function CallScreen() {
     };
     setDomRefs(refs);
     Object.assign(window, refs);
+    if (typeof window.hideVoiceSections === 'function') {
+      window.hideVoiceSections();
+    } else if (typeof window.hideChannelStatusPanel === 'function') {
+      window.hideChannelStatusPanel();
+    }
   }, []);
 
   const openCreateGroup = () => {


### PR DESCRIPTION
## Summary
- hide voice sections when CallScreen mounts

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_e_68618a25799c8326b92d183cf8dc3bf8