### PR TITLE
Fix UI events initialization after login

### DIFF
--- a/frontend/src/components/CallScreen.jsx
+++ b/frontend/src/components/CallScreen.jsx
@@ -106,6 +106,9 @@ export default function CallScreen() {
     } else if (typeof window.hideChannelStatusPanel === 'function') {
       window.hideChannelStatusPanel();
     }
+    if (typeof window.initUIEvents === 'function' && socket) {
+      window.initUIEvents(socket);
+    }
   }, []);
 
   const openCreateGroup = () => {


### PR DESCRIPTION
## Summary
- initialize `initUIEvents` once the CallScreen DOM elements exist

This ensures buttons like the leave button work after logging in.

## Testing
- `npm test` *(fails: test dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686187d947a48326a0bdf73358b15564