### PR TITLE
Initialize socket events in CallScreen

### DIFF
--- a/frontend/src/components/CallScreen.jsx
+++ b/frontend/src/components/CallScreen.jsx
@@ -109,6 +109,9 @@ export default function CallScreen() {
     if (typeof window.initUIEvents === 'function' && socket) {
       window.initUIEvents(socket);
     }
+    if (typeof window.initSocketEvents === 'function' && socket) {
+      window.initSocketEvents(socket);
+    }
   }, []);
 
   const openCreateGroup = () => {


### PR DESCRIPTION
## Summary
- call `window.initSocketEvents(socket)` in `CallScreen` when available

## Testing
- `npm test` *(fails: Cannot find module 'bcryptjs')*

------
https://chatgpt.com/codex/tasks/task_e_6861aaa4b50483268e852de30213e6a8