### PR TITLE
Emit username after UI setup

### DIFF
--- a/frontend/src/components/CallScreen.jsx
+++ b/frontend/src/components/CallScreen.jsx
@@ -118,6 +118,11 @@ export default function CallScreen() {
     if (typeof window.initSocketEvents === 'function' && socket) {
       window.initSocketEvents(socket);
     }
+    if (socket && typeof socket.emit === 'function') {
+      const nameFn = window.getUsername || (() => window.username);
+      const uname = nameFn && nameFn();
+      if (uname) socket.emit('set-username', uname);
+    }
   }, []);
 
   const openCreateGroup = () => {


### PR DESCRIPTION
## Summary
- call `set-username` once the call screen has mounted and UI event
  handlers are registered

## Testing
- `npm test` *(fails: test suite requires network access)*

------
https://chatgpt.com/codex/tasks/task_e_6861adc1d1b483269228aee8756cbb04